### PR TITLE
fix: prevent command injection through launch script comments

### DIFF
--- a/pi-extension/subagents/launch.ts
+++ b/pi-extension/subagents/launch.ts
@@ -615,10 +615,10 @@ function startPiProcess(
 	return operations.runScript(artifacts.surface, command, {
 		scriptPath: launchScriptFile,
 		scriptPreamble: [
-			`# Subagent launch script for ${resolved.request.name}`,
-			`# Generated: ${new Date().toISOString()}`,
-			`# Session: ${artifacts.sessionFile}`,
-			`# Surface: ${artifacts.surface}`,
+			shellComment(`Subagent launch script for ${resolved.request.name}`),
+			shellComment(`Generated: ${new Date().toISOString()}`),
+			shellComment(`Session: ${artifacts.sessionFile}`),
+			shellComment(`Surface: ${artifacts.surface}`),
 		].join("\n"),
 	});
 }
@@ -703,11 +703,13 @@ async function launchResumedPiSubagent(
 				`${safeName(request.name) || "resume"}-resume-${Date.now()}.sh`,
 			),
 			scriptPreamble: [
-				`# Subagent resume script for ${request.name}`,
-				`# Generated: ${new Date().toISOString()}`,
-				`# Session: ${request.sessionFile}`,
-				`# Surface: ${surface}`,
-				...(messageFile ? [`# Resume message file: ${messageFile}`] : []),
+				shellComment(`Subagent resume script for ${request.name}`),
+				shellComment(`Generated: ${new Date().toISOString()}`),
+				shellComment(`Session: ${request.sessionFile}`),
+				shellComment(`Surface: ${surface}`),
+				...(messageFile
+					? [shellComment(`Resume message file: ${messageFile}`)]
+					: []),
 			].join("\n"),
 		},
 	);
@@ -774,6 +776,10 @@ function timestampForFile(includeMilliseconds = true): string {
 			.slice(0, includeMilliseconds ? 23 : 19) +
 		(includeMilliseconds ? "Z" : "")
 	);
+}
+
+function shellComment(value: string): string {
+	return `# ${value.replace(/[\r\n\u2028\u2029]/g, " ")}`;
 }
 
 function safeName(name: string): string {

--- a/test/launch.test.ts
+++ b/test/launch.test.ts
@@ -140,6 +140,49 @@ describe("Pi launch", () => {
 		});
 	});
 
+	it("keeps untrusted launch metadata inside shell comments", async () => {
+		await withFixture(async ({ request, root, sessionDir }) => {
+			const preambles: string[] = [];
+			let pane = 0;
+			const operations: PiLaunchOperations = {
+				createPane: () => `pane-${++pane}`,
+				createWorktree: () => {
+					throw new Error("unexpected worktree creation");
+				},
+				waitForShellReady: async () => {},
+				runScript: (_surface, _command, options) => {
+					preambles.push(options.scriptPreamble);
+					return options.scriptPath;
+				},
+			};
+			const injectedName =
+				"Worker\nprintf fresh-injection\rprintf carriage-return\u2028printf line-separator\u2029printf paragraph-separator";
+
+			await launchPiSubagent({ ...request, name: injectedName }, operations);
+
+			const resumedSession = join(root, "resumed.jsonl");
+			writeFileSync(resumedSession, "existing session\n");
+			await launchPiSubagent(
+				{
+					kind: "resume",
+					id: "resume-injection",
+					name: injectedName,
+					sessionFile: resumedSession,
+					parent: { sessionId: "parent", sessionDir },
+				},
+				operations,
+			);
+
+			assert.equal(preambles.length, 2);
+			for (const preamble of preambles) {
+				const lines = preamble.split("\n");
+				assert.equal(lines.length, 4);
+				assert.ok(lines.every((line) => line.startsWith("# ")));
+				assert.doesNotMatch(preamble, /\nprintf (?:fresh|carriage)/);
+			}
+		});
+	});
+
 	it("clears inherited auto-exit state for interactive children", async () => {
 		await withFixture(async ({ request }) => {
 			let command = "";


### PR DESCRIPTION
## Summary

- normalize line terminators before embedding launch metadata in generated Bash comments
- apply the protection to fresh and resumed subagent launch scripts
- add regression coverage for LF, CR, U+2028, and U+2029 in model-controlled subagent names

## Security impact

`subagent` and `subagent_resume` names are included in executable launch-script preambles. A name containing a newline could end the comment and introduce another shell command. Since tool arguments may be model-controlled, this could bypass an unavailable or restricted `bash` tool and execute with the user account's permissions.

The new `shellComment()` helper guarantees these metadata values remain on one commented line.

## Verification

- `npm test` — 246 passed
- `npm run lint`
- `npm audit --omit=dev` — 0 vulnerabilities