### PR TITLE
fix: stop implying every writing subagent needs a worktree

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ Read [`docs/worktree-subagents.md`](docs/worktree-subagents.md) before changing 
 ## Orchestration guidance
 
 - Use ordinary panes for read-only scouts and reviewers.
-- Use unique worktree branches for independent parallel writing tasks.
+- A single or sequential writer can work in the parent checkout; reserve unique worktree branches for independent parallel writing tasks.
 - Keep overlapping or dependent writing tasks sequential unless the dependency is committed and used as the next exact base.
 - Tell worktree workers whether to commit. A good default is: edit, test, commit, report the SHA, and do not push/merge/remove.
 - The parent owns review, integration, publication, and cleanup.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ subagent({ name: "DB scout", agent: "scout", model: "<provider>/<fast-tier-id>",
 // Both return immediately; each result comes back independently.
 ```
 
-Use ordinary panes for read-only agents. Give each independent writing agent a unique managed worktree; see [Worktree subagents](docs/worktree-subagents.md).
+Use ordinary panes for read-only agents. A single or sequential writer can work in the parent checkout; give each parallel independent writing agent a unique managed worktree. See [Worktree subagents](docs/worktree-subagents.md).
 
 ## How it works
 
@@ -397,7 +397,7 @@ prompts, handoffs, and results.
 
 ### Isolated worktree runs
 
-Use one worktree per independent writing task; keep read-only agents in ordinary panes. `cwd` selects the source Git repository, `branch` must be unique, and `base` is resolved to an exact commit before creation. If `base` is omitted, the source checkout's committed `HEAD` is used. Parent-checkout changes that have not been committed are not copied.
+Use one worktree per parallel independent writing task; a single or sequential writer can work in the parent checkout, and read-only agents use ordinary panes. `cwd` selects the source Git repository, `branch` must be unique, and `base` is resolved to an exact commit before creation. If `base` is omitted, the source checkout's committed `HEAD` is used. Parent-checkout changes that have not been committed are not copied.
 
 A launch with `worktree` and an effective bundled `scout`, `reviewer`, or `adversarial-reviewer` returns a non-blocking warning. Scouts and reviewers normally need an ordinary pane; the adversarial reviewer is a coordinator that uses an ordinary pane for its child reviewers. To inspect or review an existing worker result, start an ordinary child in that retained worktree path. Project or global role overrides do not receive these bundled-role warnings.
 

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -173,7 +173,7 @@ function buildSubagentRoutingGuidelines(catalog?: string): string[] {
 		"Use fast tier for bounded mechanical work and recon, mid tier for ordinary implementation or review, and frontier tier for architecture, security, hard diagnosis, or adversarial review. Use minimal/low thinking for mechanical work, medium for ordinary work, and high+ for hard work.",
 		"Review agents must use a different provider/family than the model that produced the work; a stronger model in the same family is quality escalation, not independent review. Use an exact authenticated provider/model-id from the live catalog below, never an alias or fuzzy name.",
 		"Omitting model and thinking still inherits the parent runtime, but this is a discouraged fallback for orchestrated children.",
-		"Before launching a new group of subagents, choose a short task slug and name each new child <task>-<role>[-n], for example login-api or login-test2. Use only plan, research, ui, api, build, test, review, browser, security, perf, or merge as roles; leave existing names unchanged. After the final launch, print name | agent kind | role | model | worktree, then use each name in prompts, handoffs, and results.",
+		"Before launching a new group of subagents, choose a short task slug and name each new child <task>-<role>[-n], for example login-api or login-test2. Use only plan, research, ui, api, build, test, review, browser, security, perf, or merge as roles; leave existing names unchanged. After the final launch, print name | agent kind | role | model | worktree (if any), then use each name in prompts, handoffs, and results.",
 		catalog ??
 			"Authenticated subagent model catalog becomes available after session start.",
 	];
@@ -3055,7 +3055,8 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 			label: "Subagent",
 			description:
 				"Spawn a sub-agent in a dedicated terminal herdr pane, or in an isolated Herdr-managed Git worktree when worktree is provided. " +
-				"Use unique worktree branches for independent writing tasks; use ordinary panes for read-only tasks. The worktree base is committed state, so uncommitted parent changes are not copied. " +
+				"Use ordinary panes for read-only tasks; a single or sequential writer can work in the parent checkout without a worktree. " +
+				"Reserve unique worktree branches for parallel independent writers starting from committed state — the worktree base is committed HEAD, so uncommitted parent changes are not copied. " +
 				"Worktree runs retain their workspace after completion for parent review; they are not pushed, merged, or removed automatically. " +
 				"This is a fire-and-forget async tool: the call returns immediately with only an acknowledgement. " +
 				"When the sub-agent finishes, the harness AUTOMATICALLY delivers its result as a steer message that wakes you up and starts a new turn — you do not need to do anything to receive it. " +
@@ -3064,7 +3065,8 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 				"After spawning, either end your turn immediately, or work on other independent tasks (including spawning more subagents in parallel). The harness will wake you with the result when it is ready.",
 			promptSnippet:
 				"Spawn a sub-agent in a dedicated terminal herdr pane, or in an isolated Herdr-managed Git worktree when worktree is provided. " +
-				"Use unique worktree branches for independent writing tasks; use ordinary panes for read-only tasks. The worktree base is committed state, so uncommitted parent changes are not copied. " +
+				"Use ordinary panes for read-only tasks; a single or sequential writer can work in the parent checkout without a worktree. " +
+				"Reserve unique worktree branches for parallel independent writers starting from committed state — the worktree base is committed HEAD, so uncommitted parent changes are not copied. " +
 				"Worktree runs retain their workspace after completion for parent review; they are not pushed, merged, or removed automatically. " +
 				"This is a fire-and-forget async tool: the call returns immediately with only an acknowledgement. " +
 				"When the sub-agent finishes, the harness AUTOMATICALLY delivers its result as a steer message that wakes you up and starts a new turn — you do not need to do anything to receive it. " +

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -169,6 +169,8 @@ function getFirstText(
 
 function buildSubagentRoutingGuidelines(catalog?: string): string[] {
 	return [
+		"Act as the coordinator: decompose the work, give each child one bounded outcome — goal, allowed files, verification, and whether to commit — and keep dependent writes sequential; parallelize only independent tasks.",
+		"Children are leaves by default: they do not push, merge, deploy, or orchestrate further agents unless their task explicitly authorizes it. The parent inspects each result or worktree handoff (diff against the reported base, run relevant tests) and owns integration, verification, and cleanup.",
 		"For orchestrated subagent work, explicitly set both model and thinking for every child: first choose a fast, mid, or frontier provider-family tier matched to task complexity, then set thinking within that model's supported range.",
 		"Use fast tier for bounded mechanical work and recon, mid tier for ordinary implementation or review, and frontier tier for architecture, security, hard diagnosis, or adversarial review. Use minimal/low thinking for mechanical work, medium for ordinary work, and high+ for hard work.",
 		"Review agents must use a different provider/family than the model that produced the work; a stronger model in the same family is quality escalation, not independent review. Use an exact authenticated provider/model-id from the live catalog below, never an alias or fuzzy name.",

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -3058,6 +3058,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 				"Use ordinary panes for read-only tasks; a single or sequential writer can work in the parent checkout without a worktree. " +
 				"Reserve unique worktree branches for parallel independent writers starting from committed state — the worktree base is committed HEAD, so uncommitted parent changes are not copied. " +
 				"Worktree runs retain their workspace after completion for parent review; they are not pushed, merged, or removed automatically. " +
+				"To inspect a retained worktree result, spawn read-only agents in an ordinary pane with cwd set to that worktree path — do not create a new worktree for them. " +
 				"This is a fire-and-forget async tool: the call returns immediately with only an acknowledgement. " +
 				"When the sub-agent finishes, the harness AUTOMATICALLY delivers its result as a steer message that wakes you up and starts a new turn — you do not need to do anything to receive it. " +
 				"DO NOT write polling loops, sleep/wait commands, tail/watch scripts, or repeatedly read session/log files to detect completion. DO NOT call subagents_list or any other tool to 'check' status. All of that is wasted work — the harness handles delivery for you. " +
@@ -3068,6 +3069,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 				"Use ordinary panes for read-only tasks; a single or sequential writer can work in the parent checkout without a worktree. " +
 				"Reserve unique worktree branches for parallel independent writers starting from committed state — the worktree base is committed HEAD, so uncommitted parent changes are not copied. " +
 				"Worktree runs retain their workspace after completion for parent review; they are not pushed, merged, or removed automatically. " +
+				"To inspect a retained worktree result, spawn read-only agents in an ordinary pane with cwd set to that worktree path — do not create a new worktree for them. " +
 				"This is a fire-and-forget async tool: the call returns immediately with only an acknowledgement. " +
 				"When the sub-agent finishes, the harness AUTOMATICALLY delivers its result as a steer message that wakes you up and starts a new turn — you do not need to do anything to receive it. " +
 				"DO NOT write polling loops, sleep/wait commands, tail/watch scripts, or repeatedly read session/log files to detect completion. DO NOT call subagents_list or any other tool to 'check' status. All of that is wasted work — the harness handles delivery for you. " +


### PR DESCRIPTION
## Problem

The `subagent` tool description presented a strict binary — writing tasks get worktrees, read-only tasks get panes. Since almost every worker child writes something, parent agents concluded that every file-editing child needs a worktree, even a lone sequential worker or a small doc edit that could (or should) run in the parent checkout.

The launch-table routing guideline (`name | agent kind | role | model | worktree`) reinforced this by framing worktree as a per-child attribute every child should have. And nothing told parents where to run read-only reviewers of a retained worktree result, so they defaulted to the parent checkout (where the changes don't exist) or a fresh worktree.

## Change

String edits in `pi-extension/subagents/index.ts`:

- Tool `description` and `promptSnippet` now mirror the three-way policy already in `plan-skill.md`: ordinary panes for read-only tasks, parent checkout for single/sequential writers, worktree branches reserved for parallel independent writers starting from committed state.
- Launch-table column softened to `worktree (if any)`.
- New clause: inspect a retained worktree result with read-only agents in an ordinary pane with `cwd` set to the worktree path — do not create a new worktree for them.

## Verification

- `npm test` — all passing with the changes.
- Anti-slop lint reports an identical 48 pre-existing errors with and without this diff (verified via stash); none introduced here.

## Coordinator contract (follow-up commits)

- Two new always-visible routing-guideline bullets state the parent-as-coordinator model: the parent decomposes work into bounded child outcomes and owns integration/verification/cleanup; children are leaves by default (no push/merge/deploy/orchestration unless the task authorizes it). Previously this contract lived only in per-user AGENTS.md files and the opt-in /plan skill.
- `README.md` and `AGENTS.md` aligned with the pane-default / worktree-for-parallel-writers policy.
