### PR TITLE
Fix premature subagent completion during compaction (#17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,7 +494,7 @@ The `caller_ping` tool lets a Pi-backed subagent request help from its parent ag
 - `sessionPath` (required): Path to the child session `.jsonl` file
 - `name` (optional): Display name for the resumed pane (defaults to `Resume`)
 - `message` (optional): Follow-up prompt to send after resuming
-- `autoExit` (optional): Whether the resumed session should auto-exit after its next response. Defaults to `true` for autonomous follow-up work; set `false` when resuming for an interactive handoff.
+- `autoExit` (optional): Whether the resumed session should auto-exit after its next response fully settles. Defaults to `true` for autonomous follow-up work; set `false` when resuming for an interactive handoff.
 
 **Interaction flow:**
 
@@ -741,7 +741,7 @@ and verify them with `/subagent list` plus a smoke launch.
 | `session-mode` | string | Default child-session mode: `standalone`, `lineage-only`, or `fork` |
 | `spawning`    | boolean | Set `false` to deny all subagent-spawning tools                                                                                                                                                                                                                             |
 | `deny-tools`  | string  | Comma-separated `pi-herdr-agents` tool names to suppress; this is not a universal cross-extension deny list                                                                                                                                                                  |
-| `auto-exit`   | boolean | Auto-shutdown when the latest assistant turn does not end with `stopReason: "aborted"` — no `subagent_done` call needed. User input does not permanently disable auto-exit. Recommended for autonomous agents (scout, worker); not for interactive ones (planner). Also determines the default value of `interactive` (see below). |
+| `auto-exit`   | boolean | Auto-shutdown after Pi fully settles when the latest assistant turn does not end with `stopReason: "aborted"` — no `subagent_done` call needed. User input does not permanently disable auto-exit. Recommended for autonomous agents (scout, worker); not for interactive ones (planner). Also determines the default value of `interactive` (see below). |
 | `interactive` | boolean | Override whether stall/recovery transitions wake the parent session. Defaults to the inverse of `auto-exit`: autonomous agents (`auto-exit: true`) are non-interactive and get stall pings; agents without `auto-exit` are interactive and stay quiet. Explicit values take precedence. |
 | `cwd`         | string  | Default working directory. Absolute paths are unambiguous; relative agent-frontmatter paths resolve from Pi's agent config directory (`PI_CODING_AGENT_DIR` or `~/.pi/agent`), not the project root                                                                                                                                                                                                            |
 | `disable-model-invocation` | boolean | Hide a role from discovery surfaces like `subagents_list`. The definition remains directly invocable by exact name via `subagent({ agent: "name", ... })`. |
@@ -771,12 +771,13 @@ session-mode: lineage-only
 
 ### `auto-exit`
 
-When set to `true`, the agent session shuts down on `agent_end` unless the latest assistant message has `stopReason: "aborted"` — no explicit `subagent_done` call is needed.
+When set to `true`, the agent session shuts down on Pi's `agent_settled` event unless the latest assistant message has `stopReason: "aborted"` — no explicit `subagent_done` call is needed.
 
 **Behavior:**
 
-- The session closes on `agent_end` when the latest assistant turn does not have `stopReason: "aborted"`; a normal or error stop exits, while an aborted stop stays open.
-- User input does not permanently disable auto-exit; the latest assistant stop reason determines whether the session exits.
+- Low-level `agent_end` events do not close the session because Pi may still retry, compact and retry, or process a queued continuation.
+- After `agent_settled`, a normal or error stop exits, while an aborted stop stays open.
+- User input does not permanently disable auto-exit; the latest settled assistant stop reason determines whether the session exits.
 - The modeHint injected into the agent's task is adjusted accordingly: autonomous agents see "Complete your task autonomously." rather than instructions to call `subagent_done`
 
 **When to use:**

--- a/docs/worktree-subagents.md
+++ b/docs/worktree-subagents.md
@@ -188,7 +188,7 @@ The extension never pushes, creates a PR, merges, cherry-picks, or changes the p
 
 - **Creation failure:** the manifest is marked failed. If Herdr created the branch but returned an incomplete response, the extension reconciles a unique branch match through `/worktree list` and records any recovered workspace/path.
 - **Launch failure after creation:** the manifest is marked failed and the workspace, forked session, and path are retained. The destination is not focused unless Pi startup is confirmed.
-- **Worker failure:** summary and available Git state are returned; the workspace remains open.
+- **Worker failure:** summary and available Git state are returned; the workspace remains open. Auto-exit waits until Pi is fully settled, so a transient provider error followed by automatic compaction or retry does not end the worker early.
 - **`caller_ping`:** the child exits with `needs_help`; continue worktree-bound follow-up in the retained workspace rather than through `subagent_resume`.
 - **Parent `/reload`, `/new`, `/resume`, or `/fork`:** active in-memory watchers transfer to the replacement parent session.
 - **Full process restart or crash:** the worktree remains, but v1 does not automatically rediscover and resume its watcher.

--- a/pi-extension/subagents/subagent-done.ts
+++ b/pi-extension/subagents/subagent-done.ts
@@ -164,6 +164,8 @@ export default function (pi: ExtensionAPI) {
 
 	let userTookOver = false;
 	let agentStarted = false;
+	let latestAgentMessages: any[] | undefined;
+	let completionFinalized = false;
 
 	// Show widget + status bar on session start
 	pi.on("session_start", (_event, ctx) => {
@@ -192,41 +194,50 @@ export default function (pi: ExtensionAPI) {
 		recorder.agentStart();
 	});
 
-	pi.on("agent_end", (event, ctx) => {
-		const messages = event.messages;
-		const shouldExit =
-			autoExit && shouldAutoExitOnAgentEnd(userTookOver, messages);
-
-		if (shouldExit) {
-			// Surface stopReason: "error" turns (auto-retry exhausted, provider
-			// overload, etc.) to the parent via the .exit sidecar so the watcher
-			// can report a clear failure with the underlying error message.
-			// Without this the parent would only see exit code 0 and a stale
-			// assistant message, mistaking the crash for a successful completion.
-			const sessionFile = process.env.PI_SUBAGENT_SESSION;
-			if (sessionFile) {
-				try {
-					writeFileSync(
-						`${sessionFile}.exit`,
-						JSON.stringify(buildCompletionSidecar(messages)),
-					);
-				} catch {
-					// Best effort — the watcher can still detect the terminal sentinel
-					// after shutdown if the completion sidecar cannot be written.
-				}
-			}
-
-			recorder.agentEndDone();
-			ctx.shutdown();
-			return;
-		}
-
+	pi.on("agent_end", (event) => {
+		latestAgentMessages = event.messages;
 		recorder.agentEndWaiting();
 		if (autoExit) {
 			// Reset any recorded manual input marker. Auto-exit is decided by whether
 			// the latest agent turn completed normally, not by who initiated it.
 			userTookOver = false;
 		}
+	});
+
+	pi.on("agent_settled", (_event, ctx) => {
+		if (!autoExit || completionFinalized) return;
+
+		let messages = latestAgentMessages;
+		try {
+			const branchMessages = ctx.sessionManager
+				.getBranch()
+				.flatMap((entry) => (entry.type === "message" ? [entry.message] : []));
+			if (branchMessages.length > 0) messages = branchMessages;
+		} catch {
+			// Fall back to the latest low-level run when session evidence is unavailable.
+		}
+
+		if (!shouldAutoExitOnAgentEnd(userTookOver, messages)) return;
+		completionFinalized = true;
+
+		// Surface a settled stopReason: "error" to the parent via the .exit
+		// sidecar. Transient errors followed by retry or compaction never reach
+		// this point as the latest assistant message.
+		const sessionFile = process.env.PI_SUBAGENT_SESSION;
+		if (sessionFile) {
+			try {
+				writeFileSync(
+					`${sessionFile}.exit`,
+					JSON.stringify(buildCompletionSidecar(messages)),
+				);
+			} catch {
+				// Best effort — the watcher can still detect the terminal sentinel
+				// after shutdown if the completion sidecar cannot be written.
+			}
+		}
+
+		recorder.agentEndDone();
+		ctx.shutdown();
 	});
 
 	pi.on("turn_start", (event) => {
@@ -308,6 +319,7 @@ export default function (pi: ExtensionAPI) {
 				message: params.message,
 			};
 			writeFileSync(`${sessionFile}.exit`, JSON.stringify(exitData));
+			completionFinalized = true;
 
 			ctx.shutdown();
 			return {
@@ -338,6 +350,7 @@ export default function (pi: ExtensionAPI) {
 			if (sessionFile) {
 				writeFileSync(`${sessionFile}.exit`, JSON.stringify({ type: "done" }));
 			}
+			completionFinalized = true;
 			ctx.shutdown();
 			return {
 				content: [{ type: "text", text: "Shutting down subagent session." }],

--- a/test/test.ts
+++ b/test/test.ts
@@ -2453,6 +2453,293 @@ describe("subagent-done.ts", () => {
 		}
 	});
 
+	it("waits for settlement after a transient compaction error", () => {
+		withTempDir((dir) => {
+			const previousAutoExit = process.env.PI_SUBAGENT_AUTO_EXIT;
+			const previousSession = process.env.PI_SUBAGENT_SESSION;
+			const sessionFile = join(dir, "child.jsonl");
+			process.env.PI_SUBAGENT_AUTO_EXIT = "1";
+			process.env.PI_SUBAGENT_SESSION = sessionFile;
+			try {
+				const { api, eventHandlers } = createMockExtensionApi();
+				subagentDoneExtension(api);
+				const agentEnd = eventHandlers.get("agent_end")?.[0];
+				const agentSettled = eventHandlers.get("agent_settled")?.[0];
+				assert.ok(agentEnd);
+				assert.ok(agentSettled);
+
+				let shutdowns = 0;
+				let branch: any[] = [];
+				const ctx = {
+					shutdown: () => shutdowns++,
+					sessionManager: { getBranch: () => branch },
+				};
+				const transientError = {
+					role: "assistant",
+					stopReason: "error",
+					errorMessage: "This operation was aborted",
+				};
+				agentEnd({ messages: [transientError] }, ctx);
+				assert.equal(existsSync(`${sessionFile}.exit`), false);
+				assert.equal(shutdowns, 0);
+
+				const completed = {
+					role: "assistant",
+					stopReason: "stop",
+					content: [{ type: "text", text: "Completed after compaction." }],
+				};
+				branch = [
+					{ type: "message", message: transientError },
+					{ type: "compaction", summary: "Compacted" },
+					{ type: "message", message: completed },
+				];
+				agentEnd({ messages: [completed] }, ctx);
+				assert.equal(existsSync(`${sessionFile}.exit`), false);
+				assert.equal(shutdowns, 0);
+
+				agentSettled({}, ctx);
+				assert.deepEqual(
+					JSON.parse(readFileSync(`${sessionFile}.exit`, "utf8")),
+					{
+						type: "done",
+					},
+				);
+				assert.equal(shutdowns, 1);
+				agentSettled({}, ctx);
+				assert.equal(shutdowns, 1);
+			} finally {
+				restoreEnvVar("PI_SUBAGENT_AUTO_EXIT", previousAutoExit);
+				restoreEnvVar("PI_SUBAGENT_SESSION", previousSession);
+			}
+		});
+	});
+
+	it("uses the settled branch instead of a stale agent_end error", () => {
+		withTempDir((dir) => {
+			const previousAutoExit = process.env.PI_SUBAGENT_AUTO_EXIT;
+			const previousSession = process.env.PI_SUBAGENT_SESSION;
+			const sessionFile = join(dir, "child.jsonl");
+			process.env.PI_SUBAGENT_AUTO_EXIT = "1";
+			process.env.PI_SUBAGENT_SESSION = sessionFile;
+			try {
+				const { api, eventHandlers } = createMockExtensionApi();
+				subagentDoneExtension(api);
+				const cachedError = {
+					role: "assistant",
+					stopReason: "error",
+					errorMessage: "This operation was aborted",
+				};
+				let shutdowns = 0;
+				const ctx = {
+					shutdown: () => shutdowns++,
+					sessionManager: {
+						getBranch: () => [
+							{ type: "message", message: cachedError },
+							{
+								type: "message",
+								message: { role: "assistant", stopReason: "stop" },
+							},
+						],
+					},
+				};
+
+				eventHandlers.get("agent_end")?.[0]({ messages: [cachedError] }, ctx);
+				eventHandlers.get("agent_settled")?.[0]({}, ctx);
+				assert.deepEqual(
+					JSON.parse(readFileSync(`${sessionFile}.exit`, "utf8")),
+					{ type: "done" },
+				);
+				assert.equal(shutdowns, 1);
+			} finally {
+				restoreEnvVar("PI_SUBAGENT_AUTO_EXIT", previousAutoExit);
+				restoreEnvVar("PI_SUBAGENT_SESSION", previousSession);
+			}
+		});
+	});
+
+	it("reports a provider error that remains after settlement", () => {
+		withTempDir((dir) => {
+			const previousAutoExit = process.env.PI_SUBAGENT_AUTO_EXIT;
+			const previousSession = process.env.PI_SUBAGENT_SESSION;
+			const sessionFile = join(dir, "child.jsonl");
+			process.env.PI_SUBAGENT_AUTO_EXIT = "1";
+			process.env.PI_SUBAGENT_SESSION = sessionFile;
+			try {
+				const { api, eventHandlers } = createMockExtensionApi();
+				subagentDoneExtension(api);
+				const error = {
+					role: "assistant",
+					stopReason: "error",
+					errorMessage: "provider failed",
+				};
+				let shutdowns = 0;
+				const ctx = {
+					shutdown: () => shutdowns++,
+					sessionManager: {
+						getBranch: () => {
+							throw new Error("session branch unavailable");
+						},
+					},
+				};
+
+				eventHandlers.get("agent_end")?.[0]({ messages: [error] }, ctx);
+				assert.equal(existsSync(`${sessionFile}.exit`), false);
+				eventHandlers.get("agent_settled")?.[0]({}, ctx);
+				assert.deepEqual(
+					JSON.parse(readFileSync(`${sessionFile}.exit`, "utf8")),
+					{
+						type: "error",
+						errorMessage: "provider failed",
+						stopReason: "error",
+					},
+				);
+				assert.equal(shutdowns, 1);
+			} finally {
+				restoreEnvVar("PI_SUBAGENT_AUTO_EXIT", previousAutoExit);
+				restoreEnvVar("PI_SUBAGENT_SESSION", previousSession);
+			}
+		});
+	});
+
+	it("stays open when the settled assistant turn was aborted", () => {
+		withTempDir((dir) => {
+			const previousAutoExit = process.env.PI_SUBAGENT_AUTO_EXIT;
+			const previousSession = process.env.PI_SUBAGENT_SESSION;
+			const sessionFile = join(dir, "child.jsonl");
+			process.env.PI_SUBAGENT_AUTO_EXIT = "1";
+			process.env.PI_SUBAGENT_SESSION = sessionFile;
+			try {
+				const { api, eventHandlers } = createMockExtensionApi();
+				subagentDoneExtension(api);
+				const aborted = { role: "assistant", stopReason: "aborted" };
+				let shutdowns = 0;
+				const ctx = {
+					shutdown: () => shutdowns++,
+					sessionManager: {
+						getBranch: () => [{ type: "message", message: aborted }],
+					},
+				};
+
+				eventHandlers.get("agent_end")?.[0]({ messages: [aborted] }, ctx);
+				eventHandlers.get("agent_settled")?.[0]({}, ctx);
+				assert.equal(existsSync(`${sessionFile}.exit`), false);
+				assert.equal(shutdowns, 0);
+			} finally {
+				restoreEnvVar("PI_SUBAGENT_AUTO_EXIT", previousAutoExit);
+				restoreEnvVar("PI_SUBAGENT_SESSION", previousSession);
+			}
+		});
+	});
+
+	it("preserves caller_ping completion when the agent later settles", async () => {
+		const dir = createTestDir();
+		const previousAutoExit = process.env.PI_SUBAGENT_AUTO_EXIT;
+		const previousSession = process.env.PI_SUBAGENT_SESSION;
+		const previousName = process.env.PI_SUBAGENT_NAME;
+		const sessionFile = join(dir, "child.jsonl");
+		process.env.PI_SUBAGENT_AUTO_EXIT = "1";
+		process.env.PI_SUBAGENT_SESSION = sessionFile;
+		process.env.PI_SUBAGENT_NAME = "test-child";
+		try {
+			const { api, eventHandlers, registeredTools } = createMockExtensionApi();
+			subagentDoneExtension(api);
+			let shutdowns = 0;
+			const ctx = {
+				shutdown: () => shutdowns++,
+				sessionManager: {
+					getBranch: () => [
+						{
+							type: "message",
+							message: { role: "assistant", stopReason: "stop" },
+						},
+					],
+				},
+			};
+			const callerPing = registeredTools.find(
+				(tool) => tool.name === "caller_ping",
+			);
+			assert.ok(callerPing);
+
+			await callerPing.execute(
+				"call",
+				{ message: "Need input" },
+				null,
+				null,
+				ctx,
+			);
+			eventHandlers.get("agent_end")?.[0](
+				{ messages: [{ role: "assistant", stopReason: "stop" }] },
+				ctx,
+			);
+			eventHandlers.get("agent_settled")?.[0]({}, ctx);
+			assert.deepEqual(
+				JSON.parse(readFileSync(`${sessionFile}.exit`, "utf8")),
+				{
+					type: "ping",
+					name: "test-child",
+					message: "Need input",
+				},
+			);
+			assert.equal(shutdowns, 1);
+		} finally {
+			restoreEnvVar("PI_SUBAGENT_AUTO_EXIT", previousAutoExit);
+			restoreEnvVar("PI_SUBAGENT_SESSION", previousSession);
+			restoreEnvVar("PI_SUBAGENT_NAME", previousName);
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("leaves non-auto-exit coordinators open until subagent_done", async () => {
+		const dir = createTestDir();
+		const previousAutoExit = process.env.PI_SUBAGENT_AUTO_EXIT;
+		const previousSession = process.env.PI_SUBAGENT_SESSION;
+		const sessionFile = join(dir, "child.jsonl");
+		delete process.env.PI_SUBAGENT_AUTO_EXIT;
+		process.env.PI_SUBAGENT_SESSION = sessionFile;
+		try {
+			const { api, eventHandlers, registeredTools } = createMockExtensionApi();
+			subagentDoneExtension(api);
+			let shutdowns = 0;
+			const ctx = {
+				shutdown: () => shutdowns++,
+				sessionManager: {
+					getBranch: () => [
+						{
+							type: "message",
+							message: { role: "assistant", stopReason: "stop" },
+						},
+					],
+				},
+			};
+
+			eventHandlers.get("agent_end")?.[0](
+				{ messages: [{ role: "assistant", stopReason: "stop" }] },
+				ctx,
+			);
+			eventHandlers.get("agent_settled")?.[0]({}, ctx);
+			assert.equal(existsSync(`${sessionFile}.exit`), false);
+			assert.equal(shutdowns, 0);
+
+			const subagentDone = registeredTools.find(
+				(tool) => tool.name === "subagent_done",
+			);
+			assert.ok(subagentDone);
+			await subagentDone.execute("call", {}, null, null, ctx);
+			eventHandlers.get("agent_settled")?.[0]({}, ctx);
+			assert.deepEqual(
+				JSON.parse(readFileSync(`${sessionFile}.exit`, "utf8")),
+				{
+					type: "done",
+				},
+			);
+			assert.equal(shutdowns, 1);
+		} finally {
+			restoreEnvVar("PI_SUBAGENT_AUTO_EXIT", previousAutoExit);
+			restoreEnvVar("PI_SUBAGENT_SESSION", previousSession);
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
 	describe("shouldMarkUserTookOver", () => {
 		it("ignores the initial injected task before the first agent run", () => {
 			assert.equal(shouldMarkUserTookOver(false), false);


### PR DESCRIPTION
## Summary
Refs #17.

- Publish auto-exit completion only after Pi emits `agent_settled`, not after an intermediate `agent_end`.
- Prefer finalized session-branch messages, with cached run messages as fallback.
- Preserve genuine settled errors, manual aborts, non-auto-exit coordinators, and explicit help/completion sidecars.
- Add registered-handler regressions, including a mutation-verified stale-cache case, and update lifecycle documentation.

## Stack
- Base: #19 (`feat/adversarial-review-hardening`). Review only this PR's four-file delta.
- This PR does not include the bundled-role configuration feature or launch-cleanup fix.

## Verification
- Independent review approved the runtime change.
- `npm test`: 272 passed before the latest lint-coverage restack. The final combined stack verification below includes the additional parent coverage test.
- All 29 deterministic Herdr integration tests passed in the issue worktree. The final combined stack now passes all 30 integration tests.
- Formatting, lint, TypeScript diagnostics, package preview, and diff checks passed.

No version bump, release, or merge. Issue remains open pending landing.


## Final stack verification
The restacked chain is #19 → #20 → #21 → #22 → #23. Its tip passes 293 unit tests and all 30 deterministic Herdr integration tests. Oxlint anti-slop and Biome now cover the shipped workflow helper. Both lint and formatting coverage were verified with negative controls. No PR was merged and no version was bumped.
