### PR TITLE
Allow disabling bundled agent roles (#14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,11 +298,14 @@ cp config.json.example config.json
   },
   "models": {
     "agents": {}
+  },
+  "roles": {
+    "bundled": true
   }
 }
 ```
 
-If `config.json` is absent, status settings fall back to `config.json.example`.
+If `config.json` is absent, status and role settings fall back to `config.json.example`.
 Model routing does not read the example: no model overrides apply until a real
 `config.json` exists.
 
@@ -321,6 +324,8 @@ exact IDs from your authenticated model catalog:
   }
 }
 ```
+
+Set `roles.bundled` to `false` to exclude this package's bundled role definitions from listing and exact-name launch. It defaults to `true`. Registered role packs remain available, and global and project definitions keep their existing precedence. A role-pack name collides with a bundled role only while that bundled layer is enabled; when it is disabled, the role pack can supply that name. Run `/reload` after changing this setting.
 
 `models.default` sets the model for subagents that do not specify a model.
 `models.agents` sets per-agent defaults, keyed by the agent name passed to
@@ -705,9 +710,9 @@ the files, derives package name/version from the nearest `package.json`, and
 reports invalid paths, missing descriptions, filename/name mismatches, and
 package-layer collisions in the listing surfaces.
 
-Role packs cannot replace bundled roles, and duplicate role names from multiple
-role packs are disabled rather than resolved by extension load order. Use a
-global or project definition for an intentional override.
+Role packs cannot replace an enabled bundled role, and duplicate role names
+from multiple role packs are disabled rather than resolved by extension load
+order. Use a global or project definition for an intentional override.
 
 See [ADR-0003](docs/adr/0003-installable-role-packs.md) for the registration seam,
 collision rules, and rejected alternatives.

--- a/config.json.example
+++ b/config.json.example
@@ -4,5 +4,8 @@
   },
   "models": {
     "agents": {}
+  },
+  "roles": {
+    "bundled": true
   }
 }

--- a/docs/adr/0003-installable-role-packs.md
+++ b/docs/adr/0003-installable-role-packs.md
@@ -55,7 +55,7 @@ leaving stale roles.
 
 Listing and exact-name launch use one resolved catalog. Collection order is:
 
-1. bundled package roles;
+1. enabled bundled package roles;
 2. registered role-pack definitions;
 3. global definitions;
 4. project definitions.
@@ -72,8 +72,9 @@ override them.
 
 Within the package layer:
 
-- bundled roles are protected fallbacks;
-- a role pack colliding with a bundled name is rejected;
+- bundled roles are protected fallbacks while enabled;
+- a role pack colliding with an enabled bundled name is rejected;
+- copying `config.json.example` to package-local `config.json` and setting `roles.bundled` to `false` removes only the bundled layer; registered role packs remain package roles and may supply those names;
 - a name contributed by multiple role packs is disabled;
 - collisions never resolve through incidental extension load order.
 
@@ -84,8 +85,9 @@ instead of treating an invalid contribution as a bare agent.
 ## Reload and security
 
 Role files are read on each list or launch, so editing Markdown does not require
-`/reload`. Installing, removing, updating, or changing a role-pack extension
-uses Pi's normal reload flow. Contributor `session_shutdown` cleanup removes the
+`/reload`. Changing package-local role configuration, installing, removing,
+updating, or changing a role-pack extension uses Pi's normal reload flow.
+Contributor `session_shutdown` cleanup removes the
 old event listener before replacement extensions register. Already-running
 children retain their resolved role and lifecycle.
 

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -889,12 +889,14 @@ const BUNDLED_WORKTREE_WARNINGS = {
 function resolveWorktreeLaunchWarning(
 	params: Pick<Static<typeof SubagentParams>, "agent" | "worktree">,
 	pi?: Pick<ExtensionAPI, "events">,
+	roleConfig?: RoleConfig,
 ): string | undefined {
 	if (!params.worktree || !params.agent) return undefined;
 	const warning = Object.entries(BUNDLED_WORKTREE_WARNINGS).find(
 		([agent]) => agent === params.agent,
 	)?.[1];
-	return warning && loadAgentDefaults(params.agent, pi)?.source === "package"
+	const definition = loadAgentDefaults(params.agent, pi, roleConfig);
+	return warning && dirname(definition?.path ?? "") === getBundledAgentsDir()
 		? warning
 		: undefined;
 }

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -52,6 +52,7 @@ import {
 	type ThinkingLevel,
 } from "./runtime-routing.ts";
 import { loadModelConfig, resolveModelDefault } from "./model-config.ts";
+import { loadRoleConfig, type RoleConfig } from "./role-config.ts";
 import {
 	beginWorkflowCancellation,
 	cancelTerminationResult,
@@ -546,7 +547,10 @@ function discoverRolePackPaths(
 	return { paths: [...paths], diagnostics };
 }
 
-function discoverAgentCatalog(pi?: Pick<ExtensionAPI, "events">): AgentCatalog {
+function discoverAgentCatalog(
+	pi?: Pick<ExtensionAPI, "events">,
+	roleConfig: RoleConfig = bundledRoleConfig,
+): AgentCatalog {
 	const agents = new Map<string, ListedAgentDefinition>();
 	const diagnostics: AgentDiagnostic[] = [];
 
@@ -571,7 +575,7 @@ function discoverAgentCatalog(pi?: Pick<ExtensionAPI, "events">): AgentCatalog {
 		}
 	};
 
-	addDirectory(getBundledAgentsDir(), "package");
+	if (roleConfig.bundled) addDirectory(getBundledAgentsDir(), "package");
 
 	const discovered = discoverRolePackPaths(pi);
 	diagnostics.push(...discovered.diagnostics);
@@ -823,10 +827,12 @@ function resolveEffectiveInteractive(
 function loadAgentDefaults(
 	agentName: string,
 	pi?: Pick<ExtensionAPI, "events">,
+	roleConfig?: RoleConfig,
 ): ListedAgentDefinition | null {
 	return (
-		discoverAgentCatalog(pi).agents.find((agent) => agent.name === agentName) ??
-		null
+		discoverAgentCatalog(pi, roleConfig).agents.find(
+			(agent) => agent.name === agentName,
+		) ?? null
 	);
 }
 
@@ -926,6 +932,7 @@ function finalizeSubagentSurface(
 
 const statusConfig = loadStatusConfig();
 const modelConfig = loadModelConfig();
+const bundledRoleConfig = loadRoleConfig();
 
 const MAX_RESULT_PRESENTATION_CHARS = 16_000;
 const MAX_SESSION_REFERENCE_CHARS = 10_000;
@@ -1895,6 +1902,7 @@ export const __test__ = {
 	renderSubagentWidgetLines,
 	loadAgentDefaults,
 	discoverAgentDefinitions,
+	discoverAgentCatalog,
 	resolveEffectiveSessionMode,
 	resolveLaunchBehavior,
 	resolveEffectiveAutoExit,

--- a/pi-extension/subagents/role-config.ts
+++ b/pi-extension/subagents/role-config.ts
@@ -1,0 +1,96 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { isBoolean, isPlainObject } from "./type-guards.ts";
+
+const PACKAGE_ROOT = join(dirname(fileURLToPath(import.meta.url)), "../..");
+const DEFAULT_ROLE_CONFIG_PATH = join(PACKAGE_ROOT, "config.json");
+const ROLE_CONFIG_EXAMPLE_PATH = join(PACKAGE_ROOT, "config.json.example");
+
+export interface RoleConfig {
+	bundled: boolean;
+}
+
+function invalidRoleConfig(source: string, message: string): never {
+	throw new Error(`Invalid subagent role config in ${source}: ${message}`);
+}
+
+export function parseRoleConfig(
+	rawConfig: any,
+	source = "config.json",
+): RoleConfig {
+	if (!isPlainObject(rawConfig)) {
+		invalidRoleConfig(source, "root must be an object");
+	}
+	if (!Object.hasOwn(rawConfig, "roles")) return { bundled: true };
+	if (!isPlainObject(rawConfig.roles)) {
+		invalidRoleConfig(source, "roles must be an object");
+	}
+
+	const unsupportedKeys = Object.keys(rawConfig.roles).filter(
+		(key) => key !== "bundled",
+	);
+	if (unsupportedKeys.length > 0) {
+		invalidRoleConfig(
+			source,
+			`roles has unsupported key(s): ${unsupportedKeys.join(", ")}`,
+		);
+	}
+	if (!Object.hasOwn(rawConfig.roles, "bundled")) return { bundled: true };
+	if (!isBoolean(rawConfig.roles.bundled)) {
+		invalidRoleConfig(source, "roles.bundled must be a boolean");
+	}
+	return { bundled: rawConfig.roles.bundled };
+}
+
+interface RoleConfigSource {
+	sourcePath: string;
+	rawConfig: string;
+}
+
+function readRoleConfigFile(
+	configPath: string,
+	examplePath: string,
+): RoleConfigSource {
+	try {
+		return {
+			sourcePath: configPath,
+			rawConfig: readFileSync(configPath, "utf8"),
+		};
+	} catch (error) {
+		// SAFETY: readFileSync only throws Node fs errors here, which carry code.
+		const errno = error as NodeJS.ErrnoException;
+		if (errno.code !== "ENOENT") throw error;
+	}
+
+	try {
+		return {
+			sourcePath: examplePath,
+			rawConfig: readFileSync(examplePath, "utf8"),
+		};
+	} catch (error) {
+		// SAFETY: see the preceding readFileSync error handling.
+		const errno = error as NodeJS.ErrnoException;
+		if (errno.code === "ENOENT") {
+			throw new Error(
+				`Missing subagent role config. Expected ${configPath} or ${examplePath}.`,
+			);
+		}
+		throw error;
+	}
+}
+
+export function loadRoleConfig(
+	configPath = DEFAULT_ROLE_CONFIG_PATH,
+	examplePath = ROLE_CONFIG_EXAMPLE_PATH,
+): RoleConfig {
+	const { sourcePath, rawConfig } = readRoleConfigFile(configPath, examplePath);
+	let parsed;
+	try {
+		parsed = JSON.parse(rawConfig);
+	} catch (error) {
+		const detail = error instanceof Error ? error.message : String(error);
+		throw new Error(`Invalid JSON in subagent config ${sourcePath}: ${detail}`);
+	}
+	return parseRoleConfig(parsed, sourcePath);
+}

--- a/test/test.ts
+++ b/test/test.ts
@@ -3882,7 +3882,7 @@ describe("tool registration", () => {
 		assert.match(subagentTool.description, /retain.*parent review/i);
 	});
 
-	it("warns when an effective bundled role normally uses an ordinary pane", async () => {
+	it("warns only when the resolved role is bundled", async () => {
 		const testApi = subagentsModule.__test__;
 		const worktree = { branch: "review/unneeded-worktree" };
 
@@ -3914,6 +3914,97 @@ describe("tool registration", () => {
 				undefined,
 			);
 		});
+
+		await withIsolatedAgentEnv(
+			async ({ projectDir, projectAgentsDir, globalAgentsDir }) => {
+				const namedRolesDir = join(projectDir, "named-pack", "roles");
+				const namelessRolesDir = join(projectDir, "nameless-pack", "roles");
+				mkdirSync(namedRolesDir, { recursive: true });
+				mkdirSync(namelessRolesDir, { recursive: true });
+				writeFileSync(
+					join(namedRolesDir, "..", "package.json"),
+					JSON.stringify({ name: "@acme/writing-roles" }),
+				);
+				writeAgentFile(
+					namedRolesDir,
+					"scout",
+					"description: Writing scout\ntools: write",
+				);
+				writeAgentFile(
+					namelessRolesDir,
+					"reviewer",
+					"description: Writing reviewer\ntools: write",
+				);
+				writeAgentFile(
+					namelessRolesDir,
+					"adversarial-reviewer",
+					"description: Writing adversarial reviewer\ntools: write",
+				);
+
+				const { api } = createMockExtensionApi();
+				api.events.on(
+					"pi-herdr-subagents:roles:discover:v1",
+					(request: { register(path: string): void }) => {
+						request.register(namedRolesDir);
+						request.register(namelessRolesDir);
+					},
+				);
+				const disabled = { bundled: false };
+				for (const agent of ["scout", "reviewer", "adversarial-reviewer"]) {
+					assert.equal(
+						testApi.resolveWorktreeLaunchWarning(
+							{ agent, worktree },
+							api,
+							disabled,
+						),
+						undefined,
+					);
+				}
+
+				writeAgentFile(
+					globalAgentsDir,
+					"scout",
+					"description: Global writing scout\ntools: write",
+				);
+				writeAgentFile(
+					projectAgentsDir,
+					"reviewer",
+					"description: Project writing reviewer\ntools: write",
+				);
+				assert.equal(
+					testApi.resolveWorktreeLaunchWarning(
+						{ agent: "scout", worktree },
+						api,
+						disabled,
+					),
+					undefined,
+				);
+				assert.equal(
+					testApi.resolveWorktreeLaunchWarning(
+						{ agent: "reviewer", worktree },
+						api,
+						disabled,
+					),
+					undefined,
+				);
+				assert.equal(
+					testApi.resolveWorktreeLaunchWarning(
+						{ agent: "unknown", worktree },
+						api,
+						disabled,
+					),
+					undefined,
+				);
+				assert.equal(
+					testApi.resolveWorktreeLaunchWarning(
+						{ agent: "scout" },
+						api,
+						disabled,
+					),
+					undefined,
+				);
+			},
+		);
 	});
 
 	it("renders partial subagent tool-call args without throwing", () => {

--- a/test/test.ts
+++ b/test/test.ts
@@ -53,6 +53,10 @@ import {
 	resolveModelDefault,
 } from "../pi-extension/subagents/model-config.ts";
 import {
+	loadRoleConfig,
+	parseRoleConfig,
+} from "../pi-extension/subagents/role-config.ts";
+import {
 	advanceStatusState,
 	capStatusLines,
 	classifyStatus,
@@ -1452,8 +1456,148 @@ describe("model configuration", () => {
 	});
 });
 
+describe("role configuration", () => {
+	it("defaults bundled roles to enabled when omitted", () => {
+		assert.deepEqual(parseRoleConfig({}), { bundled: true });
+		assert.deepEqual(parseRoleConfig({ roles: {} }), { bundled: true });
+	});
+
+	it("rejects explicit null and non-object role settings", () => {
+		for (const roles of [null, [], "roles"]) {
+			assert.throws(
+				() => parseRoleConfig({ roles }),
+				/roles must be an object/,
+			);
+		}
+		for (const bundled of [null, "false", []]) {
+			assert.throws(
+				() => parseRoleConfig({ roles: { bundled } }),
+				/roles\.bundled must be a boolean/,
+			);
+		}
+	});
+
+	it("loads the shared example when local config is absent", () => {
+		withTempDir((dir) => {
+			const examplePath = join(dir, "config.json.example");
+			writeFileSync(examplePath, JSON.stringify({ roles: { bundled: false } }));
+
+			assert.deepEqual(loadRoleConfig(join(dir, "config.json"), examplePath), {
+				bundled: false,
+			});
+		});
+	});
+
+	it("rejects malformed bundled-role settings without falling back", () => {
+		assert.throws(
+			() => parseRoleConfig({ roles: { bundled: "false" } }),
+			/roles\.bundled must be a boolean/,
+		);
+		withTempDir((dir) => {
+			const configPath = join(dir, "config.json");
+			const examplePath = join(dir, "config.json.example");
+			writeFileSync(
+				configPath,
+				JSON.stringify({ roles: { bundled: "false" } }),
+			);
+			writeFileSync(examplePath, JSON.stringify({ roles: { bundled: false } }));
+
+			assert.throws(
+				() => loadRoleConfig(configPath, examplePath),
+				/roles\.bundled must be a boolean/,
+			);
+		});
+	});
+});
+
 describe("subagent discovery", () => {
 	const testApi = subagentsModule.__test__;
+
+	it("excludes bundled roles while retaining role-pack and override roles", async () => {
+		await withIsolatedAgentEnv(
+			async ({ projectDir, projectAgentsDir, globalAgentsDir }) => {
+				const rolesDir = join(projectDir, "scout-pack", "roles");
+				mkdirSync(rolesDir, { recursive: true });
+				writeFileSync(
+					join(rolesDir, "..", "package.json"),
+					JSON.stringify({ name: "@acme/scout-pack", version: "1.0.0" }),
+				);
+				writeAgentFile(
+					rolesDir,
+					"scout",
+					"description: Role-pack scout enabled without bundled roles",
+				);
+
+				const disabled = { bundled: false };
+				const emptyCatalog = testApi.discoverAgentCatalog(undefined, disabled);
+				assert.equal(
+					emptyCatalog.agents.some((agent) => agent.name === "scout"),
+					false,
+					"listing excludes bundled scouts when disabled",
+				);
+				assert.equal(
+					testApi.loadAgentDefaults("scout", undefined, disabled),
+					null,
+					"exact-name lookup cannot launch an omitted bundled scout",
+				);
+
+				const { api } = createMockExtensionApi();
+				api.events.on(
+					"pi-herdr-subagents:roles:discover:v1",
+					(request: { register(path: string): void }) =>
+						request.register(rolesDir),
+				);
+				const catalog = testApi.discoverAgentCatalog(api, disabled);
+				assert.equal(
+					catalog.agents.find((agent) => agent.name === "scout")?.provider,
+					"@acme/scout-pack",
+					"a role pack may supply a name that no enabled bundled role owns",
+				);
+				assert.equal(
+					catalog.diagnostics.some(
+						(diagnostic) => diagnostic.code === "bundled-role-collision",
+					),
+					false,
+				);
+				assert.equal(
+					testApi.loadAgentDefaults("worker", api, disabled),
+					null,
+					"exact-name lookup cannot launch an omitted bundled role",
+				);
+
+				writeAgentFile(
+					globalAgentsDir,
+					"global-scout",
+					"description: Global scout",
+				);
+				assert.equal(
+					testApi.loadAgentDefaults("global-scout", api, disabled)?.source,
+					"global",
+				);
+
+				writeAgentFile(
+					globalAgentsDir,
+					"scout",
+					"description: Global scout override",
+				);
+				assert.equal(
+					testApi.loadAgentDefaults("scout", api, disabled)?.source,
+					"global",
+					"a global definition can supply a disabled bundled name",
+				);
+				writeAgentFile(
+					projectAgentsDir,
+					"scout",
+					"description: Project scout override",
+				);
+				assert.equal(
+					testApi.loadAgentDefaults("scout", api, disabled)?.source,
+					"project",
+					"a project definition retains precedence over a global definition",
+				);
+			},
+		);
+	});
 
 	it("loads session-mode from frontmatter", async () => {
 		await withIsolatedAgentEnv(async ({ projectAgentsDir }) => {


### PR DESCRIPTION
## Summary
Refs #14.

- Add package-local `roles.bundled`, enabled by default.
- When disabled, exclude built-in definitions from both listings and exact-name invocation.
- Preserve installed role packs and global/project definitions; apply bundled-name collision protection only while the bundled layer is enabled.
- Validate configuration strictly and document `/reload`, safe configuration examples, and precedence.

## Stack
- Base: #20 (`stack/17-settled-auto-exit`), which is based on #19.
- Review this PR's six-file role-configuration delta; the auto-exit fix belongs to #20.

## Verification
- Independent review validated implementation; its two documentation findings were corrected and inspected.
- `npm test`: 278 passed on this branch after the warning fix and lint-coverage restack.
- `npm run test:integration`: all 29 passed, no skips.
- Formatting, lint, TypeScript diagnostics, package preview, and diff checks passed.
- Configuration examples were checked with all three configuration parsers.

No version bump, release, or merge. Issue remains open pending landing.


## Final stack verification
The restacked chain is #19 → #20 → #21 → #22 → #23. Its tip passes 293 unit tests and all 30 deterministic Herdr integration tests. Oxlint anti-slop and Biome now cover the shipped workflow helper. Both lint and formatting coverage were verified with negative controls. No PR was merged and no version was bumped.
