### PR TITLE
Close owned panes after failed subagent launches (#18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ pi install git:github.com/giuseppecrj/pi-herdr-agents@main
 
 Smoke-test delivery with an autonomous subagent instructed to return one exact marker. Success means the marker itself—not only a generic wake-up notice—automatically appears in the parent turn.
 
-Subagent tabs, panes, and worktree workspaces are created without stealing keyboard focus. Launch commands target child panes by explicit ID, so focus and command delivery are independent. Note: the `interactive` option controls parent status notifications, not terminal focus.
+Subagent tabs, panes, and worktree workspaces are created without stealing keyboard focus. Launch commands target child panes by explicit ID, so focus and command delivery are independent. If a fresh or resumed launch fails, the extension closes the ordinary pane that it created and preserves the original launch error. It does not close a caller-supplied surface, and managed worktree workspaces remain retained on failure. Note: the `interactive` option controls parent status notifications, not terminal focus.
 
 ## What's Included
 

--- a/docs/worktree-subagents.md
+++ b/docs/worktree-subagents.md
@@ -186,6 +186,7 @@ The extension never pushes, creates a PR, merges, cherry-picks, or changes the p
 
 ## Failure, help, and restart behavior
 
+- **Ordinary launch failure:** if a fresh launch or `subagent_resume` fails after the extension creates its pane, the extension closes that pane and preserves the original launch error. It does not close a caller-supplied surface.
 - **Creation failure:** the manifest is marked failed. If Herdr created the branch but returned an incomplete response, the extension reconciles a unique branch match through `/worktree list` and records any recovered workspace/path.
 - **Launch failure after creation:** the manifest is marked failed and the workspace, forked session, and path are retained. The destination is not focused unless Pi startup is confirmed.
 - **Worker failure:** summary and available Git state are returned; the workspace remains open. Auto-exit waits until Pi is fully settled, so a transient provider error followed by automatic compaction or retry does not end the worker early.

--- a/pi-extension/subagents/launch.ts
+++ b/pi-extension/subagents/launch.ts
@@ -19,6 +19,7 @@ import {
 	seedSubagentSessionFile,
 } from "./session.ts";
 import {
+	closePane,
 	createSubagentPane,
 	createSubagentWorktree,
 	runScriptInPane,
@@ -151,6 +152,7 @@ export interface PiLaunchOperations {
 		command: string,
 		options: { scriptPath: string; scriptPreamble: string },
 	): string;
+	closePane(pane: string): void;
 	waitForPiReady?(
 		surface: string,
 		sessionFile: string,
@@ -164,6 +166,7 @@ const defaultOperations: PiLaunchOperations = {
 	createWorktree: createSubagentWorktree,
 	waitForShellReady,
 	runScript: runScriptInPane,
+	closePane,
 	waitForPiReady,
 	focusWorkspace,
 };
@@ -243,9 +246,10 @@ async function launchFreshPiSubagent(
 	operations: PiLaunchOperations,
 ): Promise<PiRunningChild> {
 	const resolved = resolveLaunchRequest(request);
-	const surface = prepareLaunchSurface(resolved, operations);
+	let surface: PreparedSurface | undefined;
 
 	try {
+		surface = prepareLaunchSurface(resolved, operations);
 		const session = prepareChildSession(resolved, surface);
 		const handoffArtifacts = request.handoff
 			? prepareTaskArtifacts(resolved, session)
@@ -275,7 +279,17 @@ async function launchFreshPiSubagent(
 		}
 		return createRunningChild(resolved, artifacts, launchScriptFile);
 	} catch (error) {
-		if (!surface.worktree) throw error;
+		if (!surface) throw error;
+		if (!surface.worktree) {
+			if (!request.surface) {
+				try {
+					operations.closePane(surface.surface);
+				} catch {
+					// The launch error remains authoritative when cleanup also fails.
+				}
+			}
+			throw error;
+		}
 		const handoff = captureWorktreeHandoff(surface.worktree);
 		try {
 			persistWorktreeResult(surface.worktree, "failed", handoff);
@@ -673,73 +687,82 @@ async function launchResumedPiSubagent(
 		request.parent.sessionId,
 	);
 	const surface = operations.createPane(request.name);
-	await operations.waitForShellReady(surface);
-	const activityFile = getSubagentActivityFile(artifactDir, id);
-	mkdirSync(dirname(activityFile), { recursive: true });
+	try {
+		await operations.waitForShellReady(surface);
+		const activityFile = getSubagentActivityFile(artifactDir, id);
+		mkdirSync(dirname(activityFile), { recursive: true });
 
-	let messageFile: string | undefined;
-	if (request.message) {
-		messageFile = join(
-			artifactDir,
-			"subagent-resume",
-			`${safeName(request.name) || "resume"}-${timestampForFile(false)}.md`,
-		);
-		mkdirSync(dirname(messageFile), { recursive: true });
-		writeFileSync(messageFile, request.message, "utf8");
-	}
-
-	const env = [
-		...(process.env.PI_CODING_AGENT_DIR
-			? [`PI_CODING_AGENT_DIR=${shellQuote(process.env.PI_CODING_AGENT_DIR)}`]
-			: []),
-		`PI_SUBAGENT_NAME=${shellQuote(request.name)}`,
-		`PI_SUBAGENT_SESSION=${shellQuote(request.sessionFile)}`,
-		`PI_SUBAGENT_ID=${shellQuote(id)}`,
-		`PI_SUBAGENT_ACTIVITY_FILE=${shellQuote(activityFile)}`,
-		`PI_SUBAGENT_AUTO_EXIT=${autoExit ? "1" : "0"}`,
-	];
-	const command = [
-		...env,
-		"pi",
-		"--session",
-		shellQuote(request.sessionFile),
-		"-e",
-		shellQuote(join(SUBAGENTS_DIR, "subagent-done.ts")),
-		...(messageFile ? [shellQuote(`@${messageFile}`)] : []),
-	].join(" ");
-	const launchScriptFile = operations.runScript(
-		surface,
-		`${command}; echo '__SUBAGENT_DONE_'$?'__'`,
-		{
-			scriptPath: join(
+		let messageFile: string | undefined;
+		if (request.message) {
+			messageFile = join(
 				artifactDir,
-				"subagent-scripts",
-				`${safeName(request.name) || "resume"}-resume-${Date.now()}.sh`,
-			),
-			scriptPreamble: [
-				shellComment(`Subagent resume script for ${request.name}`),
-				shellComment(`Generated: ${new Date().toISOString()}`),
-				shellComment(`Session: ${request.sessionFile}`),
-				shellComment(`Surface: ${surface}`),
-				...(messageFile
-					? [shellComment(`Resume message file: ${messageFile}`)]
-					: []),
-			].join("\n"),
-		},
-	);
-	return {
-		id,
-		name: request.name,
-		task: request.message ?? "resumed session",
-		surface,
-		startTime,
-		sessionFile: request.sessionFile,
-		launchScriptFile,
-		activityFile,
-		interactive,
-		runtimePlan: undefined,
-		lifecycle: createLifecycle(startTime),
-	};
+				"subagent-resume",
+				`${safeName(request.name) || "resume"}-${timestampForFile(false)}.md`,
+			);
+			mkdirSync(dirname(messageFile), { recursive: true });
+			writeFileSync(messageFile, request.message, "utf8");
+		}
+
+		const env = [
+			...(process.env.PI_CODING_AGENT_DIR
+				? [`PI_CODING_AGENT_DIR=${shellQuote(process.env.PI_CODING_AGENT_DIR)}`]
+				: []),
+			`PI_SUBAGENT_NAME=${shellQuote(request.name)}`,
+			`PI_SUBAGENT_SESSION=${shellQuote(request.sessionFile)}`,
+			`PI_SUBAGENT_ID=${shellQuote(id)}`,
+			`PI_SUBAGENT_ACTIVITY_FILE=${shellQuote(activityFile)}`,
+			`PI_SUBAGENT_AUTO_EXIT=${autoExit ? "1" : "0"}`,
+		];
+		const command = [
+			...env,
+			"pi",
+			"--session",
+			shellQuote(request.sessionFile),
+			"-e",
+			shellQuote(join(SUBAGENTS_DIR, "subagent-done.ts")),
+			...(messageFile ? [shellQuote(`@${messageFile}`)] : []),
+		].join(" ");
+		const launchScriptFile = operations.runScript(
+			surface,
+			`${command}; echo '__SUBAGENT_DONE_'$?'__'`,
+			{
+				scriptPath: join(
+					artifactDir,
+					"subagent-scripts",
+					`${safeName(request.name) || "resume"}-resume-${Date.now()}.sh`,
+				),
+				scriptPreamble: [
+					shellComment(`Subagent resume script for ${request.name}`),
+					shellComment(`Generated: ${new Date().toISOString()}`),
+					shellComment(`Session: ${request.sessionFile}`),
+					shellComment(`Surface: ${surface}`),
+					...(messageFile
+						? [shellComment(`Resume message file: ${messageFile}`)]
+						: []),
+				].join("\n"),
+			},
+		);
+		return {
+			id,
+			name: request.name,
+			task: request.message ?? "resumed session",
+			surface,
+			startTime,
+			sessionFile: request.sessionFile,
+			launchScriptFile,
+			activityFile,
+			interactive,
+			runtimePlan: undefined,
+			lifecycle: createLifecycle(startTime),
+		};
+	} catch (error) {
+		try {
+			operations.closePane(surface);
+		} catch {
+			// The launch error remains authoritative when cleanup also fails.
+		}
+		throw error;
+	}
 }
 
 export function buildSubagentToolAllowlist(

--- a/test/launch.test.ts
+++ b/test/launch.test.ts
@@ -82,6 +82,7 @@ describe("Pi launch", () => {
 			const projectAgentDir = join(project, ".pi", "agent");
 			mkdirSync(projectAgentDir, { recursive: true });
 			const events: string[] = [];
+			const closed: string[] = [];
 			let command = "";
 			let scriptPath = "";
 			const operations: PiLaunchOperations = {
@@ -104,11 +105,15 @@ describe("Pi launch", () => {
 					scriptPath = options.scriptPath;
 					return options.scriptPath;
 				},
+				closePane(surface) {
+					closed.push(surface);
+				},
 			};
 
 			const running = await launchPiSubagent(request, operations);
 
 			assert.deepEqual(events, ["create", "ready", "run"]);
+			assert.deepEqual(closed, []);
 			assert.equal(running.id, "child-1");
 			assert.equal(running.surface, "pane-1");
 			assert.equal(running.launchScriptFile, scriptPath);
@@ -140,6 +145,171 @@ describe("Pi launch", () => {
 		});
 	});
 
+	for (const kind of ["fresh", "resume"] as const) {
+		for (const failurePoint of ["readiness", "command delivery"] as const) {
+			it(`closes its ${kind} pane once when ${failurePoint} fails`, async () => {
+				await withFixture(async ({ request, root, sessionDir }) => {
+					const pane = `pane-${kind}`;
+					const closed: string[] = [];
+					const sessionFile = join(root, "resumed.jsonl");
+					writeFileSync(sessionFile, "existing session\n");
+					const launchRequest: FreshPiLaunchRequest | ResumePiLaunchRequest =
+						kind === "fresh"
+							? request
+							: {
+									kind: "resume",
+									id: "resume-failure",
+									name: "Resume worker",
+									sessionFile,
+									parent: { sessionId: "parent", sessionDir },
+								};
+					const expectedError = `${kind} ${failurePoint} failed`;
+					const operations: PiLaunchOperations = {
+						createPane: () => pane,
+						createWorktree: () => {
+							throw new Error("unexpected worktree creation");
+						},
+						waitForShellReady: async () => {
+							if (failurePoint === "readiness") throw new Error(expectedError);
+						},
+						runScript: (_surface, _command, options) => {
+							if (failurePoint === "command delivery")
+								throw new Error(expectedError);
+							return options.scriptPath;
+						},
+						closePane(surface) {
+							closed.push(surface);
+						},
+					};
+
+					await assert.rejects(
+						launchPiSubagent(launchRequest, operations),
+						new RegExp(expectedError),
+					);
+					assert.deepEqual(closed, [pane]);
+				});
+			});
+		}
+	}
+
+	it("closes its fresh pane when artifact preparation fails", async () => {
+		await withFixture(async ({ request, root }) => {
+			const blockedSessionDir = join(root, "blocked-session-dir");
+			writeFileSync(blockedSessionDir, "not a directory\n");
+			const closed: string[] = [];
+			const operations: PiLaunchOperations = {
+				createPane: () => "pane-artifact-failure",
+				createWorktree: () => {
+					throw new Error("unexpected worktree creation");
+				},
+				waitForShellReady: async () => {},
+				runScript: () => {
+					throw new Error("must not run");
+				},
+				closePane(surface) {
+					closed.push(surface);
+				},
+			};
+
+			await assert.rejects(
+				launchPiSubagent(
+					{
+						...request,
+						parent: { ...request.parent, sessionDir: blockedSessionDir },
+					},
+					operations,
+				),
+			);
+			assert.deepEqual(closed, ["pane-artifact-failure"]);
+		});
+	});
+
+	it("does not invent pane ownership when creation fails", async () => {
+		await withFixture(async ({ request }) => {
+			const closed: string[] = [];
+			const operations: PiLaunchOperations = {
+				createPane: () => {
+					throw new Error("pane creation failed");
+				},
+				createWorktree: () => {
+					throw new Error("unexpected worktree creation");
+				},
+				waitForShellReady: async () => {
+					throw new Error("must not wait");
+				},
+				runScript: () => {
+					throw new Error("must not run");
+				},
+				closePane(surface) {
+					closed.push(surface);
+				},
+			};
+
+			await assert.rejects(
+				launchPiSubagent(request, operations),
+				/pane creation failed/,
+			);
+			assert.deepEqual(closed, []);
+		});
+	});
+
+	it("preserves the launch error when ordinary pane cleanup fails", async () => {
+		await withFixture(async ({ request }) => {
+			let cleanupAttempts = 0;
+			const operations: PiLaunchOperations = {
+				createPane: () => "pane-cleanup-error",
+				createWorktree: () => {
+					throw new Error("unexpected worktree creation");
+				},
+				waitForShellReady: async () => {
+					throw new Error("original launch error");
+				},
+				runScript: () => {
+					throw new Error("must not run");
+				},
+				closePane: () => {
+					cleanupAttempts++;
+					throw new Error("cleanup error");
+				},
+			};
+
+			await assert.rejects(
+				launchPiSubagent(request, operations),
+				(error: Error) => error.message === "original launch error",
+			);
+			assert.equal(cleanupAttempts, 1);
+		});
+	});
+
+	it("does not close a caller-supplied surface when launch fails", async () => {
+		await withFixture(async ({ request }) => {
+			const closed: string[] = [];
+			const operations: PiLaunchOperations = {
+				createPane: () => {
+					throw new Error("must not create a pane");
+				},
+				createWorktree: () => {
+					throw new Error("unexpected worktree creation");
+				},
+				waitForShellReady: async () => {
+					throw new Error("supplied surface readiness failed");
+				},
+				runScript: () => {
+					throw new Error("must not run");
+				},
+				closePane(surface) {
+					closed.push(surface);
+				},
+			};
+
+			await assert.rejects(
+				launchPiSubagent({ ...request, surface: "caller-pane" }, operations),
+				/supplied surface readiness failed/,
+			);
+			assert.deepEqual(closed, []);
+		});
+	});
+
 	it("keeps untrusted launch metadata inside shell comments", async () => {
 		await withFixture(async ({ request, root, sessionDir }) => {
 			const preambles: string[] = [];
@@ -154,6 +324,7 @@ describe("Pi launch", () => {
 					preambles.push(options.scriptPreamble);
 					return options.scriptPath;
 				},
+				closePane: () => {},
 			};
 			const injectedName =
 				"Worker\nprintf fresh-injection\rprintf carriage-return\u2028printf line-separator\u2029printf paragraph-separator";
@@ -205,6 +376,7 @@ describe("Pi launch", () => {
 						command = value;
 						return options.scriptPath;
 					},
+					closePane: () => {},
 				},
 			);
 
@@ -238,6 +410,7 @@ describe("Pi launch", () => {
 						command = value;
 						return options.scriptPath;
 					},
+					closePane: () => {},
 				},
 			);
 
@@ -264,6 +437,7 @@ describe("Pi launch", () => {
 			process.env.PI_CODING_AGENT_DIR = join(root, "isolated-agent");
 			try {
 				const events: string[] = [];
+				const closed: string[] = [];
 				let command = "";
 				let scriptPath = "";
 				let scriptPreamble = "";
@@ -296,11 +470,15 @@ describe("Pi launch", () => {
 						scriptPreamble = options.scriptPreamble;
 						return options.scriptPath;
 					},
+					closePane(surface) {
+						closed.push(surface);
+					},
 				};
 
 				const running = await launchPiSubagent(request, operations);
 
 				assert.deepEqual(events, ["create", "ready", "run"]);
+				assert.deepEqual(closed, []);
 				assert.equal(running.id, "resume-1");
 				assert.equal(running.name, "Resume worker");
 				assert.equal(running.task, "Use the approved schema.");
@@ -375,6 +553,7 @@ describe("Pi launch", () => {
 							command = value;
 							return options.scriptPath;
 						},
+						closePane: () => {},
 					},
 				);
 
@@ -458,6 +637,9 @@ describe("Pi launch", () => {
 					events.push("run");
 					command = value;
 					return options.scriptPath;
+				},
+				closePane: () => {
+					throw new Error("must retain the worktree workspace");
 				},
 			};
 
@@ -578,6 +760,9 @@ describe("Pi launch", () => {
 					assert.equal(workspaceId, "workspace-handoff");
 					events.push("focus");
 				},
+				closePane: () => {
+					throw new Error("must retain the worktree workspace");
+				},
 			};
 
 			const result = await launchPiWorktreeHandoff(
@@ -665,6 +850,7 @@ describe("Pi launch", () => {
 					.join("\n") + "\n",
 			);
 			const worktreePath = join(root, "shell-timeout-tree");
+			const closed: string[] = [];
 			const manifestFile = join(
 				sessionDir,
 				"artifacts",
@@ -706,10 +892,14 @@ describe("Pi launch", () => {
 						focusWorkspace: () => {
 							throw new Error("must not focus");
 						},
+						closePane: (surface) => {
+							closed.push(surface);
+						},
 					},
 				),
 				/shell timeout/i,
 			);
+			assert.deepEqual(closed, []);
 			const manifest = JSON.parse(readFileSync(manifestFile, "utf8"));
 			assert.equal(manifest.state, "failed");
 			assert.equal(existsSync(manifest.sessionFile), true);
@@ -807,6 +997,9 @@ describe("Pi launch", () => {
 						focusWorkspace: () => {
 							focused = true;
 						},
+						closePane: () => {
+							throw new Error("must retain the worktree workspace");
+						},
 					},
 				),
 				/worktree retained.*pi exited before startup/i,
@@ -899,6 +1092,9 @@ describe("Pi launch", () => {
 				},
 				focusWorkspace() {
 					throw new Error("focus must not run after launch failure");
+				},
+				closePane() {
+					throw new Error("must retain the worktree workspace");
 				},
 			};
 


### PR DESCRIPTION
## Summary
Refs #18.

- Close only the ordinary pane created by a failed fresh or resumed launch transaction.
- Cover readiness, artifact preparation, and command-delivery failures while preserving the original launch error if cleanup also fails.
- Leave caller-supplied surfaces, successful launches, and retained managed worktree workspaces untouched.
- Add ownership and failure-injection regressions through the actual launch seam.

## Stack
- Base: #21 (`stack/14-disable-bundled-roles`), above #20 and #19.
- Review this PR's four-file launch-cleanup delta only.

## Verification
- Independent review approved with no P0–P2 findings.
- All 19 focused launch tests passed, including red/green cleanup regressions and mutation checks.
- The final combined stack passed 293 unit tests and all 30 deterministic Herdr integration tests.
- Oxlint anti-slop, Biome, changed-file TypeScript checks, package preview, and diff checks passed.
- Range-diff confirmed the cleanup commit is unchanged by restacking.

No version bump, release, or merge. The issue remains open pending landing.
