### PR TITLE
Add configurable split-pane subagent launches (#16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,11 +301,15 @@ cp config.json.example config.json
   },
   "roles": {
     "bundled": true
+  },
+  "panes": {
+    "mode": "tab",
+    "direction": "right"
   }
 }
 ```
 
-If `config.json` is absent, status and role settings fall back to `config.json.example`.
+If `config.json` is absent, status, role, and pane settings fall back to `config.json.example`.
 Model routing does not read the example: no model overrides apply until a real
 `config.json` exists.
 
@@ -325,7 +329,11 @@ exact IDs from your authenticated model catalog:
 }
 ```
 
-Set `roles.bundled` to `false` to exclude this package's bundled role definitions from listing and exact-name launch. It defaults to `true`. Registered role packs remain available, and global and project definitions keep their existing precedence. A role-pack name collides with a bundled role only while that bundled layer is enabled; when it is disabled, the role pack can supply that name. Run `/reload` after changing this setting.
+Set `roles.bundled` to `false` to exclude this package's bundled role definitions from listing and exact-name launch. It defaults to `true`. Registered role packs remain available, and global and project definitions keep their existing precedence. A role-pack name collides with a bundled role only while that bundled layer is enabled; when it is disabled, the role pack can supply that name.
+
+Set `panes.mode` to `"split"` to open ordinary public `subagent` and `subagent_resume` launches, including bare forks and `/iterate`, as splits of the stable parent pane. Set `panes.direction` to `"right"` or `"down"`; it defaults to `"right"` and is ignored when mode is `"tab"`. The default `"tab"` mode preserves existing behavior. Managed worktrees still use separate workspaces, while approved workflow readers and `/btw` keep their existing tab behavior.
+
+Run `/reload` after changing role, model, or pane settings.
 
 `models.default` sets the model for subagents that do not specify a model.
 `models.agents` sets per-agent defaults, keyed by the agent name passed to
@@ -344,7 +352,7 @@ only, to keep approved workflow runtimes deterministic.
 `config.json` is gitignored in the source tree so local overrides are not
 committed from a checkout. On an installed package root, treat it as disposable
 local state that package updates may replace. Run `/reload` after changing it;
-status and model configuration are loaded when the extension starts.
+status, model, role, and pane configuration are loaded when the extension starts.
 
 ---
 

--- a/config.json.example
+++ b/config.json.example
@@ -7,5 +7,9 @@
   },
   "roles": {
     "bundled": true
+  },
+  "panes": {
+    "mode": "tab",
+    "direction": "right"
   }
 }

--- a/pi-extension/subagents/herdr.ts
+++ b/pi-extension/subagents/herdr.ts
@@ -179,6 +179,23 @@ function buildTabCreateArgs(
 	];
 }
 
+function buildPaneSplitArgs(
+	parentPaneId: string,
+	direction: "right" | "down",
+	cwd: string,
+): string[] {
+	return [
+		"pane",
+		"split",
+		parentPaneId,
+		"--direction",
+		direction,
+		"--no-focus",
+		"--cwd",
+		cwd,
+	];
+}
+
 function buildWorktreeCreateArgs(
 	name: string,
 	cwd: string,
@@ -342,16 +359,9 @@ export function createHerdrSurfaceSplit(
 	direction: "right" | "down",
 ): string {
 	const parentPaneId = getHerdrParentPaneId();
-	const output = herdrExec([
-		"pane",
-		"split",
-		parentPaneId,
-		"--direction",
-		direction,
-		"--no-focus",
-		"--cwd",
-		process.cwd(),
-	]);
+	const output = herdrExec(
+		buildPaneSplitArgs(parentPaneId, direction, process.cwd()),
+	);
 	const paneId = extractHerdrPaneId(output, "pane split");
 	try {
 		herdrExec(["pane", "rename", paneId, name]);
@@ -731,6 +741,7 @@ export function focusHerdrWorkspace(workspaceId: string): void {
 export const __herdrTest__ = {
 	buildCurrentPaneArgs,
 	buildTabCreateArgs,
+	buildPaneSplitArgs,
 	buildWorktreeCreateArgs,
 	parseHerdrJson,
 	extractHerdrPaneId,

--- a/pi-extension/subagents/launch.ts
+++ b/pi-extension/subagents/launch.ts
@@ -12,6 +12,7 @@ import { fileURLToPath } from "node:url";
 import { getSubagentActivityFile } from "./activity.ts";
 import { createLifecycle, type SubagentLifecycle } from "./lifecycle.ts";
 import type { ResolvedRuntimePlan } from "./runtime-routing.ts";
+import { createSubagentPaneFactory, loadPaneConfig } from "./pane-config.ts";
 import { HerdrWorktreeCreateError } from "./herdr.ts";
 import type { JsonObject } from "./type-guards.ts";
 import {
@@ -22,6 +23,7 @@ import {
 	closePane,
 	createSubagentPane,
 	createSubagentWorktree,
+	splitCurrentPane,
 	runScriptInPane,
 	shellQuote,
 	waitForPiReady,
@@ -161,8 +163,14 @@ export interface PiLaunchOperations {
 	focusWorkspace?(workspaceId: string): void;
 }
 
+const paneConfig = loadPaneConfig();
+
 const defaultOperations: PiLaunchOperations = {
-	createPane: createSubagentPane,
+	createPane: createSubagentPaneFactory(
+		paneConfig,
+		createSubagentPane,
+		splitCurrentPane,
+	),
 	createWorktree: createSubagentWorktree,
 	waitForShellReady,
 	runScript: runScriptInPane,

--- a/pi-extension/subagents/pane-config.ts
+++ b/pi-extension/subagents/pane-config.ts
@@ -1,0 +1,135 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { isPlainObject, isString } from "./type-guards.ts";
+
+const PACKAGE_ROOT = join(dirname(fileURLToPath(import.meta.url)), "../..");
+const DEFAULT_PANE_CONFIG_PATH = join(PACKAGE_ROOT, "config.json");
+const PANE_CONFIG_EXAMPLE_PATH = join(PACKAGE_ROOT, "config.json.example");
+
+export type PaneMode = "tab" | "split";
+export type PaneDirection = "right" | "down";
+
+export interface PaneConfig {
+	mode: PaneMode;
+	direction: PaneDirection;
+}
+
+type PaneCreator = (name: string) => string;
+type SplitPaneCreator = (name: string, direction: PaneDirection) => string;
+
+function invalidPaneConfig(source: string, message: string): never {
+	throw new Error(`Invalid subagent pane config in ${source}: ${message}`);
+}
+
+export function parsePaneConfig(
+	rawConfig: any,
+	source = "config.json",
+): PaneConfig {
+	if (!isPlainObject(rawConfig)) {
+		invalidPaneConfig(source, "root must be an object");
+	}
+	if (!Object.hasOwn(rawConfig, "panes")) {
+		return { mode: "tab", direction: "right" };
+	}
+	if (!isPlainObject(rawConfig.panes)) {
+		invalidPaneConfig(source, "panes must be an object");
+	}
+
+	const unsupportedKeys = Object.keys(rawConfig.panes).filter(
+		(key) => key !== "mode" && key !== "direction",
+	);
+	if (unsupportedKeys.length > 0) {
+		invalidPaneConfig(
+			source,
+			`panes has unsupported key(s): ${unsupportedKeys.join(", ")}`,
+		);
+	}
+
+	let mode: PaneMode = "tab";
+	if (Object.hasOwn(rawConfig.panes, "mode")) {
+		if (
+			!isString(rawConfig.panes.mode) ||
+			(rawConfig.panes.mode !== "tab" && rawConfig.panes.mode !== "split")
+		) {
+			invalidPaneConfig(source, 'panes.mode must be "tab" or "split"');
+		}
+		mode = rawConfig.panes.mode;
+	}
+
+	let direction: PaneDirection = "right";
+	if (Object.hasOwn(rawConfig.panes, "direction")) {
+		if (
+			!isString(rawConfig.panes.direction) ||
+			(rawConfig.panes.direction !== "right" &&
+				rawConfig.panes.direction !== "down")
+		) {
+			invalidPaneConfig(source, 'panes.direction must be "right" or "down"');
+		}
+		direction = rawConfig.panes.direction;
+	}
+
+	return { mode, direction };
+}
+
+interface PaneConfigSource {
+	sourcePath: string;
+	rawConfig: string;
+}
+
+function readPaneConfigFile(
+	configPath: string,
+	examplePath: string,
+): PaneConfigSource {
+	try {
+		return {
+			sourcePath: configPath,
+			rawConfig: readFileSync(configPath, "utf8"),
+		};
+	} catch (error) {
+		// SAFETY: readFileSync only throws Node fs errors here, which carry code.
+		const errno = error as NodeJS.ErrnoException;
+		if (errno.code !== "ENOENT") throw error;
+	}
+
+	try {
+		return {
+			sourcePath: examplePath,
+			rawConfig: readFileSync(examplePath, "utf8"),
+		};
+	} catch (error) {
+		// SAFETY: see the preceding readFileSync error handling.
+		const errno = error as NodeJS.ErrnoException;
+		if (errno.code === "ENOENT") {
+			throw new Error(
+				`Missing subagent pane config. Expected ${configPath} or ${examplePath}.`,
+			);
+		}
+		throw error;
+	}
+}
+
+export function loadPaneConfig(
+	configPath = DEFAULT_PANE_CONFIG_PATH,
+	examplePath = PANE_CONFIG_EXAMPLE_PATH,
+): PaneConfig {
+	const { sourcePath, rawConfig } = readPaneConfigFile(configPath, examplePath);
+	let parsed;
+	try {
+		parsed = JSON.parse(rawConfig);
+	} catch (error) {
+		const detail = error instanceof Error ? error.message : String(error);
+		throw new Error(`Invalid JSON in subagent config ${sourcePath}: ${detail}`);
+	}
+	return parsePaneConfig(parsed, sourcePath);
+}
+
+export function createSubagentPaneFactory(
+	config: PaneConfig,
+	createTab: PaneCreator,
+	createSplit: SplitPaneCreator,
+): PaneCreator {
+	return config.mode === "split"
+		? (name) => createSplit(name, config.direction)
+		: createTab;
+}

--- a/test/integration/harness.ts
+++ b/test/integration/harness.ts
@@ -31,6 +31,7 @@ import {
 	isTerminalAvailable,
 	createSubagentPane,
 	createSubagentWorktree,
+	splitCurrentPane,
 	runInPane,
 	runScriptInPane,
 	readPane,
@@ -46,6 +47,7 @@ type MuxBackend = "herdr";
 export {
 	createSubagentPane,
 	createSubagentWorktree,
+	splitCurrentPane,
 	runInPane,
 	runScriptInPane,
 	readPane,

--- a/test/integration/mux-surface.test.ts
+++ b/test/integration/mux-surface.test.ts
@@ -18,7 +18,9 @@ import {
 	createTestEnv,
 	cleanupTestEnv,
 	createTrackedSurface,
+	createSubagentPane,
 	createSubagentWorktree,
+	splitCurrentPane,
 	getFocusedSurface,
 	untrackSurface,
 	runInPane,
@@ -32,6 +34,10 @@ import {
 	waitForScreen,
 	type TestEnv,
 } from "./harness.ts";
+import {
+	createSubagentPaneFactory,
+	parsePaneConfig,
+} from "../../pi-extension/subagents/pane-config.ts";
 
 const backends = getAvailableBackends();
 
@@ -80,6 +86,56 @@ for (const backend of backends) {
 				waitForScreen(childB, new RegExp(`FOCUS_B_${markerB}`), 20_000, 50),
 			]);
 			assert.equal(getFocusedSurface(backend), focusedPane);
+		});
+
+		it("splits the stable parent without stealing focus or closing it", async () => {
+			const parentPane = createTrackedSurface(env, "split-parent");
+			await waitForPaneReady(parentPane);
+			const focusedPane = getFocusedSurface(backend);
+			const parentBefore = JSON.parse(
+				execFileSync("herdr", ["pane", "get", parentPane], {
+					encoding: "utf8",
+				}),
+			).result.pane;
+			const createConfiguredPane = createSubagentPaneFactory(
+				parsePaneConfig({ panes: { mode: "split", direction: "down" } }),
+				createSubagentPane,
+				splitCurrentPane,
+			);
+			const previousParentPane = process.env.HERDR_PANE_ID;
+			let child: string | undefined;
+			try {
+				process.env.HERDR_PANE_ID = parentPane;
+				child = createConfiguredPane("split-child");
+			} finally {
+				if (previousParentPane === undefined) delete process.env.HERDR_PANE_ID;
+				else process.env.HERDR_PANE_ID = previousParentPane;
+			}
+
+			try {
+				await waitForPaneReady(child);
+				const childInfo = JSON.parse(
+					execFileSync("herdr", ["pane", "get", child], {
+						encoding: "utf8",
+					}),
+				).result.pane;
+				assert.notEqual(childInfo.pane_id, parentPane);
+				assert.equal(childInfo.tab_id, parentBefore.tab_id);
+				assert.equal(getFocusedSurface(backend), focusedPane);
+
+				const marker = uniqueId();
+				runInPane(child, `echo "SPLIT_${marker}"`);
+				await waitForScreen(child, new RegExp(`SPLIT_${marker}`), 20_000, 50);
+			} finally {
+				closePane(child);
+			}
+
+			const parentAfter = JSON.parse(
+				execFileSync("herdr", ["pane", "get", parentPane], {
+					encoding: "utf8",
+				}),
+			).result.pane;
+			assert.equal(parentAfter.pane_id, parentPane);
 		});
 
 		it("creates an isolated worktree workspace without stealing focus", async () => {

--- a/test/launch.test.ts
+++ b/test/launch.test.ts
@@ -18,6 +18,7 @@ import {
 	type PiLaunchOperations,
 	type ResumePiLaunchRequest,
 } from "../pi-extension/subagents/launch.ts";
+import { createSubagentPaneFactory } from "../pi-extension/subagents/pane-config.ts";
 
 function fixture() {
 	const root = mkdtempSync(join(tmpdir(), "subagent-launch-test-"));
@@ -191,6 +192,46 @@ describe("Pi launch", () => {
 			});
 		}
 	}
+
+	it("closes an owned split child rather than its stable parent on launch failure", async () => {
+		await withFixture(async ({ request }) => {
+			const parentPane = "parent-pane";
+			const childPane = "split-child-pane";
+			const closed: string[] = [];
+			const operations: PiLaunchOperations = {
+				createPane: createSubagentPaneFactory(
+					{ mode: "split", direction: "down" },
+					() => {
+						throw new Error("must not create a tab");
+					},
+					(name, direction) => {
+						assert.equal(name, "Worker");
+						assert.equal(direction, "down");
+						return childPane;
+					},
+				),
+				createWorktree: () => {
+					throw new Error("unexpected worktree creation");
+				},
+				waitForShellReady: async () => {
+					throw new Error("split readiness failed");
+				},
+				runScript: () => {
+					throw new Error("must not run");
+				},
+				closePane(surface) {
+					closed.push(surface);
+				},
+			};
+
+			await assert.rejects(
+				launchPiSubagent(request, operations),
+				/split readiness failed/,
+			);
+			assert.deepEqual(closed, [childPane]);
+			assert.equal(closed.includes(parentPane), false);
+		});
+	});
 
 	it("closes its fresh pane when artifact preparation fails", async () => {
 		await withFixture(async ({ request, root }) => {

--- a/test/test.ts
+++ b/test/test.ts
@@ -57,6 +57,11 @@ import {
 	parseRoleConfig,
 } from "../pi-extension/subagents/role-config.ts";
 import {
+	createSubagentPaneFactory,
+	loadPaneConfig,
+	parsePaneConfig,
+} from "../pi-extension/subagents/pane-config.ts";
+import {
 	advanceStatusState,
 	capStatusLines,
 	classifyStatus,
@@ -1372,6 +1377,88 @@ describe("status.ts", () => {
 		assert.match(aggregate, /^Subagent status:/);
 		assert.match(aggregate, /\+2 more running\./);
 		assert.doesNotMatch(aggregate, /\/tmp|\.jsonl/);
+	});
+});
+
+describe("pane configuration", () => {
+	it("defaults to tabs and rightward splits when panes are absent", () => {
+		assert.deepEqual(parsePaneConfig({}), {
+			mode: "tab",
+			direction: "right",
+		});
+	});
+
+	it("parses split mode and direction", () => {
+		assert.deepEqual(
+			parsePaneConfig({ panes: { mode: "split", direction: "down" } }),
+			{ mode: "split", direction: "down" },
+		);
+	});
+
+	it("rejects invalid pane settings", () => {
+		for (const panes of [null, [], "split"]) {
+			assert.throws(
+				() => parsePaneConfig({ panes }),
+				/panes must be an object/,
+			);
+		}
+		assert.throws(
+			() => parsePaneConfig({ panes: { mode: "window" } }),
+			/panes\.mode must be "tab" or "split"/,
+		);
+		assert.throws(
+			() => parsePaneConfig({ panes: { direction: "left" } }),
+			/panes\.direction must be "right" or "down"/,
+		);
+		assert.throws(
+			() => parsePaneConfig({ panes: { mode: "tab", extra: true } }),
+			/panes has unsupported key\(s\): extra/,
+		);
+	});
+
+	it("loads the shared example when local config is absent", () => {
+		withTempDir((dir) => {
+			const examplePath = join(dir, "config.json.example");
+			writeFileSync(
+				examplePath,
+				JSON.stringify({ panes: { mode: "split", direction: "down" } }),
+			);
+
+			assert.deepEqual(loadPaneConfig(join(dir, "config.json"), examplePath), {
+				mode: "split",
+				direction: "down",
+			});
+		});
+	});
+
+	it("uses tabs unchanged and passes split direction to the split creator", () => {
+		const calls: string[] = [];
+		const createTab = (name: string) => {
+			calls.push(`tab:${name}`);
+			return "tab-pane";
+		};
+		const createSplit = (name: string, direction: "right" | "down") => {
+			calls.push(`split:${name}:${direction}`);
+			return "split-pane";
+		};
+
+		assert.equal(
+			createSubagentPaneFactory(
+				{ mode: "tab", direction: "down" },
+				createTab,
+				createSplit,
+			)("Scout"),
+			"tab-pane",
+		);
+		assert.equal(
+			createSubagentPaneFactory(
+				{ mode: "split", direction: "right" },
+				createTab,
+				createSplit,
+			)("Reviewer"),
+			"split-pane",
+		);
+		assert.deepEqual(calls, ["tab:Scout", "split:Reviewer:right"]);
 	});
 });
 
@@ -5549,6 +5636,22 @@ describe("herdr.ts", () => {
 				"current",
 				"--current",
 			]);
+		});
+
+		it("targets an explicit stable parent when splitting without focus", () => {
+			assert.deepEqual(
+				__herdrTest__.buildPaneSplitArgs("parent-pane", "down", "/repo"),
+				[
+					"pane",
+					"split",
+					"parent-pane",
+					"--direction",
+					"down",
+					"--no-focus",
+					"--cwd",
+					"/repo",
+				],
+			);
 		});
 
 		it("targets the current workspace when creating a subagent tab", () => {


### PR DESCRIPTION
## Summary
Refs #16.

- Add package-local `panes.mode` (`tab` or `split`) and `panes.direction` (`right` or `down`). Defaults preserve tabs.
- Apply the configured factory to ordinary public fresh, resumed, bare-fork, and `/iterate` launches.
- Keep workflow-reader tabs, BTW tabs, and managed worktree workspaces unchanged.
- Target the parent pane explicitly without taking keyboard focus, and retain transaction-owned cleanup from #22.
- Add configuration, routing, argument, cleanup, and test-owned real-Herdr split coverage.

## Stack
- Base: #22 (`stack/18-launch-pane-cleanup`), above #21, #20, and #19.
- Review this PR's nine-file split-pane feature delta only.

## Verification
- Independent review approved with no P0–P2 findings.
- Final combined stack: 293 unit tests and 30 deterministic Herdr integration tests passed, no failures or skips.
- The split regression uses only test-owned panes, restores `HERDR_PANE_ID`, verifies command delivery and focus, and closes the child without closing its parent.
- Oxlint anti-slop, Biome, package preview, and diff checks passed. Changed production and integration files have no TypeScript diagnostics. Existing inferred-project fixture diagnostics in unchanged portions of `test/test.ts` remain outside this feature.
- Range-diff confirmed the feature commit is unchanged by restacking.

No version bump, release, or merge. The issue remains open pending landing.
