### PR TITLE
Fix subagent lifecycle, resume permissions, and failure reporting

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -33,7 +33,7 @@ The runner-owned append-only `run.jsonl` that starts with approval binding the w
 _Avoid_: User-authored plan, mutable audit log, duplicated result
 
 **Terminal lifecycle**:
-Completed read and review panes close after result capture while child session files and run evidence remain. Writer-worktree retention belongs to a deferred writer workflow.
+Every workflow terminal path stops queued work and accounts for active read and review panes before checkout disposal and final delivery. Completed panes close after result capture while child session files and run evidence remain. Unconfirmed child exit retains the checkout and ends failed with `cancel_termination_failed`. Writer-worktree retention belongs to a deferred writer workflow.
 _Avoid_: Retaining every clean pane, deleting review evidence
 
 **Restart boundary**:

--- a/README.md
+++ b/README.md
@@ -478,6 +478,8 @@ Parameters:
 - If process identity cannot be captured for an active pane, the pane remains present after close, or any captured process still lives after the bounded wait, the checkout is retained and the run ends `failed` with `cancel_termination_failed`. Successful cancellation is not reported in that case.
 - A successful cancel writes one `cancelled` terminal journal event and one result-free delivery. Repeated cancel is idempotent and returns the authoritative terminal outcome (including a prior fail-closed result).
 
+Every terminal path—normal completion, early script return, script or Worker failure, deadline, interruption, and explicit cancellation—stops queued work and accounts for active workflow children before checkout disposal or final delivery. If active-child exit cannot be confirmed, the checkout is retained and the authoritative outcome is `failed` with `cancel_termination_failed`.
+
 There is no list, status, resume, or history action in v1. Workflow ownership and the Worker survive `/reload` in the same Pi process, and the latest parent API receives one final delivery. A full process restart reconciles interruption without replay: startup marks only the last known running journal event as `interrupted`, leaves sessions, journals, and reader checkouts in place, and requires a new approved run.
 
 ### Bundled `orchestrate` skill
@@ -490,7 +492,7 @@ The script and journal retain every original child envelope. Synthesis receives 
 
 The runner-owned checkout contains only the pinned commit. Parent staged, unstaged, and untracked state is not review evidence. Effective child tools are the resolved role allowlist intersected with the runner maximum (`read`, `grep`, `find`, and `ls`) and deny rules. Public `subagent` results can be abbreviated above 16,000 characters, but workflow scripts receive complete child reports within their explicit bounds. Operational failures are preserved without silent fallback; recovery is a new exact approved run.
 
-The parent calls `herdr_workflow prepare`, presents its packet unchanged, and waits for the exact `APPROVE <8-character lowercase hash prefix>` reply before calling `start`. After start, one final delivery is sent without polling. Cancellation is fail-closed and retains evidence when process exit cannot be confirmed. Same-process `/reload` preserves ownership; full restart records interruption without replay, restart, cleanup, or history. Workflow JavaScript runs in a Worker-hosted `vm` for event-loop availability only; neither the Worker nor `vm` is a security boundary, and worktrees do not provide process or security isolation.
+The parent calls `herdr_workflow prepare`, presents its packet unchanged, and waits for the exact `APPROVE <8-character lowercase hash prefix>` reply before calling `start`. After start, one final delivery is sent without polling. Every terminal path is fail-closed: it accounts for queued and active children before checkout disposal and delivery, retaining evidence when process exit cannot be confirmed. Same-process `/reload` preserves ownership; full restart records interruption without replay, restart, cleanup, or history. Workflow JavaScript runs in a Worker-hosted `vm` for event-loop availability only; neither the Worker nor `vm` is a security boundary, and worktrees do not provide process or security isolation.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -342,12 +342,25 @@ followed by agent frontmatter, per-agent config, the global default, and finally
 the parent model. Model values must be exact authenticated `provider/model-id`
 references. A value can contain an ordered comma-separated fallback list, for
 example `provider/preferred, provider/fallback`. The extension validates every
-candidate before launch, retries the preferred model normally, then launches
-later candidates only after a provider/agent request failure. A completed child
-result, including a negative task result, never switches models. Completion
-metadata and the status widget report the model actually used; an exhausted
-list reports every attempted model. Workflow metadata accepts one exact model
-only, to keep approved workflow runtimes deterministic.
+candidate before launch, then launches later candidates only after the selected
+child settles with a provider/agent error. Pi owns any automatic transient
+retrying inside that child; the extension does not infer retry counts or
+permanence from the error text. A completed child result, including a negative
+task result, never switches models. Completion metadata reports the requested
+candidate, every attempted candidate, the model actually used, and each raw
+model failure in attempt order when fallbacks are tried. Workflow metadata accepts one exact
+model only, to keep approved workflow runtimes deterministic.
+
+A catalog-listed model and configured authentication do not prove that the
+active provider account can use that model. Providers may reject an account /
+model combination only when the request is made. The completion preserves each
+raw provider reason with its model and suggests checking account access,
+spawning a new subagent with a supported model, or choosing an appropriate
+configured fallback. `subagent_resume` does not select a model and should be
+used only after the session's stored model is usable. The completion does not
+claim a permanent failure or a retry count that Pi has not exposed. Reliable
+structured permanence and retry counts require an upstream Pi/ExtensionAPI
+diagnostics seam for final provider errors and retry outcomes.
 
 `config.json` is gitignored in the source tree so local overrides are not
 committed from a checkout. On an installed package root, treat it as disposable

--- a/README.md
+++ b/README.md
@@ -511,6 +511,8 @@ The `caller_ping` tool lets a Pi-backed subagent request help from its parent ag
 - `message` (optional): Follow-up prompt to send after resuming
 - `autoExit` (optional): Whether the resumed session should auto-exit after its next response fully settles. Defaults to `true` for autonomous follow-up work; set `false` when resuming for an interactive handoff.
 
+Each public child stores a session-adjacent versioned launch-policy sidecar. Public resume restores its resolved tool allowlist and denied subagent tools rather than looking up the current role, so later role changes cannot widen a child. An intentionally unrestricted launch remains unrestricted (no `--tools` argument); a restricted launch restores its exact allowlist. The `autoExit` override still controls whether `subagent_done` is available, while `caller_ping` remains available. Missing, malformed, or unsupported policy fails closed before a pane is created with recovery guidance. Public resume also rejects workflow-owned and managed-worktree child sessions; use their retained workflow evidence or workspace instead.
+
 **Interaction flow:**
 
 1. Child calls `caller_ping({ message: "Not sure which schema to use" })`

--- a/README.md
+++ b/README.md
@@ -636,8 +636,11 @@ specific exact authenticated `provider/model-id`.
 
 `tools` is passed to Pi's `--tools` allowlist and may name any registered
 built-in, extension, or custom tool. Listing a tool does not install its
-extension. Likewise, `skills` names must already be discoverable by Pi; this
-package does not install role prerequisites.
+extension. Use one non-empty inline comma-separated scalar, such as
+`tools: read, grep`; do not use YAML lists, containers, quotes, or comments.
+Omitting `tools` intentionally leaves the role unrestricted. Likewise, `skills`
+names must already be discoverable by Pi; this package does not install role
+prerequisites.
 
 ### 3. Verify and launch
 
@@ -740,9 +743,17 @@ collision rules, and rejected alternatives.
 - Generic roles omit `model` unless a particular runtime is functionally required.
 - `/subagent list` shows the expected source and a smoke launch succeeds.
 
-The current parser is permissive: unsupported or unknown frontmatter may be
-ignored rather than rejected. Compare definitions against the reference below
-and verify them with `/subagent list` plus a smoke launch.
+Capability declarations are strict: use the unquoted, unindented keys
+`tools:`, `deny-tools:`, and `spawning:` exactly once when present. Declare
+`tools` and `deny-tools` as non-empty inline comma-separated scalars, and
+`spawning` as exactly `true` or `false`. YAML lists, containers, multiline
+values, quotes, comments, empty values, duplicates, noncanonical key spelling,
+and invalid booleans are rejected. A role with an invalid capability declaration
+is excluded from discovery, and an exact-name launch reports the diagnostic
+before creating a Herdr pane or worktree. Other unsupported or unknown
+frontmatter may still be ignored.
+Compare definitions against the reference below and verify them with
+`/subagent list` plus a smoke launch.
 
 ### Frontmatter Reference
 
@@ -753,11 +764,11 @@ and verify them with `/subagent list` plus a smoke launch.
 | `model`       | string  | Optional exact authenticated Pi model default or ordered comma-separated fallback list; omit to use per-agent config, global config, then the parent                                                                                                                       |
 | `thinking`    | string  | Optional Pi thinking default (`off` through `max`); omit to inherit the parent                                                                                                                                   |
 | `system-prompt` | string | `append` passes the agent body through Pi's appended system prompt; `replace` replaces Pi's default system prompt. Without this field, the body is included in the task wrapper                                                                                                                                                                                                                                 |
-| `tools`       | string  | Comma-separated Pi `--tools` allowlist; may contain any registered built-in, extension, or custom tool name                                                                                                                                                                 |
+| `tools`       | string  | One non-empty inline comma-separated Pi `--tools` allowlist under the exact unquoted key `tools:`; may contain any registered built-in, extension, or custom tool name. Omit to leave unrestricted. YAML lists, containers, multiline values, quotes, comments, noncanonical keys, and duplicates are rejected. |
 | `skills`      | string  | Comma-separated installed skill names to auto-load. Use this plural form for new definitions; legacy project/global definitions using singular `skill` remain compatible. |
 | `session-mode` | string | Default child-session mode: `standalone`, `lineage-only`, or `fork` |
-| `spawning`    | boolean | Set `false` to deny all subagent-spawning tools                                                                                                                                                                                                                             |
-| `deny-tools`  | string  | Comma-separated `pi-herdr-agents` tool names to suppress; this is not a universal cross-extension deny list                                                                                                                                                                  |
+| `spawning`    | boolean | Set exactly `false` to deny all subagent-spawning tools under the exact unquoted key `spawning:`. Only one `true` or `false` declaration is accepted. |
+| `deny-tools`  | string  | One non-empty inline comma-separated `pi-herdr-agents` tool list to suppress under the exact unquoted key `deny-tools:`; this is not a universal cross-extension deny list. YAML lists, containers, multiline values, quotes, comments, noncanonical keys, and duplicates are rejected. |
 | `auto-exit`   | boolean | Auto-shutdown after Pi fully settles when the latest assistant turn does not end with `stopReason: "aborted"` — no `subagent_done` call needed. User input does not permanently disable auto-exit. Recommended for autonomous agents (scout, worker); not for interactive ones (planner). Also determines the default value of `interactive` (see below). |
 | `interactive` | boolean | Override whether stall/recovery transitions wake the parent session. Defaults to the inverse of `auto-exit`: autonomous agents (`auto-exit: true`) are non-interactive and get stall pings; agents without `auto-exit` are interactive and stay quiet. Explicit values take precedence. |
 | `cwd`         | string  | Default working directory. Absolute paths are unambiguous; relative agent-frontmatter paths resolve from Pi's agent config directory (`PI_CODING_AGENT_DIR` or `~/.pi/agent`), not the project root                                                                                                                                                                                                            |

--- a/docs/adr/0003-installable-role-packs.md
+++ b/docs/adr/0003-installable-role-packs.md
@@ -29,7 +29,14 @@ roles are listed or launched.
 
 Role packs use the existing agent-definition format. The filename stem is the
 canonical role name; `name` frontmatter is optional and, when present, must
-match the stem. `description` is required for contributed roles.
+match the stem. `description` is required for contributed roles. Capability
+declarations are strict: use the unquoted, unindented keys `tools:`,
+`deny-tools:`, and `spawning:` exactly once when present. `tools` and
+`deny-tools` must each be one non-empty inline comma-separated scalar, and
+`spawning` must be exactly `true` or `false`. YAML lists, containers,
+multiline or empty values, quotes, comments, noncanonical key spelling, and
+duplicate declarations are invalid; omit `tools` to intentionally leave a role
+unrestricted.
 
 ## Why
 
@@ -80,7 +87,10 @@ Within the package layer:
 
 Invalid registrations do not suppress unrelated roles. Listing surfaces report
 concise diagnostics, and an exact-name launch reports the matching diagnostic
-instead of treating an invalid contribution as a bare agent.
+instead of treating an invalid contribution as a bare agent. An invalid
+capability declaration makes that role name unavailable at its precedence layer
+rather than falling through to a lower-priority role, and launch rejects it
+before Herdr creates a pane or worktree.
 
 ## Reload and security
 

--- a/docs/orchestrated-review-workflow-plan.md
+++ b/docs/orchestrated-review-workflow-plan.md
@@ -19,7 +19,7 @@ Shipped:
 - bounded parallel review, fresh synthesis, and explicit non-retryable failure evidence for parent-guided recovery;
 - a preferred adversarial procedure in the existing authoring skill, with risk-based discovery and candidate-dependent verification;
 - one final parent delivery; and
-- fail-closed cancellation with process-exit confirmation before checkout cleanup.
+- fail-closed terminal cleanup with process-exit confirmation for every outcome before checkout disposal.
 
 Package and runtime slices are shipped. Remaining work is limited to deferred writer behavior and any future workflow extensions.
 
@@ -146,7 +146,7 @@ The LLM cannot authorize execution by passing approval text in tool arguments. `
 7. dispose the reader checkout only after termination is confirmed;
 8. append one `cancelled` terminal event and deliver one bounded cancellation receipt.
 
-If a captured process remains after the bounded wait, retain the checkout and append `failed` with `cancel_termination_failed`; never report successful cancellation or clean up underneath a live child. All completion, failure, interruption, and cancellation paths use the same compare-and-set terminal gate. Repeated cancellation is idempotent.
+If a captured process remains after the bounded wait, retain the checkout and append `failed` with `cancel_termination_failed`; never report successful cancellation or clean up underneath a live child. All completion, early return, failure, interruption, deadline, and cancellation paths use the same compare-and-set terminal gate and terminate queued or active children before checkout disposal and delivery. Repeated cancellation is idempotent.
 
 ## Workflow metadata
 

--- a/docs/worktree-subagents.md
+++ b/docs/worktree-subagents.md
@@ -190,11 +190,11 @@ The extension never pushes, creates a PR, merges, cherry-picks, or changes the p
 - **Creation failure:** the manifest is marked failed. If Herdr created the branch but returned an incomplete response, the extension reconciles a unique branch match through `/worktree list` and records any recovered workspace/path.
 - **Launch failure after creation:** the manifest is marked failed and the workspace, forked session, and path are retained. The destination is not focused unless Pi startup is confirmed.
 - **Worker failure:** summary and available Git state are returned; the workspace remains open. Auto-exit waits until Pi is fully settled, so a transient provider error followed by automatic compaction or retry does not end the worker early.
-- **`caller_ping`:** the child exits with `needs_help`; continue worktree-bound follow-up in the retained workspace rather than through `subagent_resume`.
+- **`caller_ping`:** the child exits with `needs_help`; continue worktree-bound follow-up in the retained workspace rather than through `subagent_resume`. Public `subagent_resume` rejects managed-worktree child sessions before creating a pane so it cannot silently lose worktree ownership or policy.
 - **Parent `/reload`, `/new`, `/resume`, or `/fork`:** active in-memory watchers transfer to the replacement parent session.
 - **Full process restart or crash:** the worktree remains, but v1 does not automatically rediscover and resume its watcher.
 
-`subagent_resume` resumes a session in a new ordinary Herdr pane. It does not reattach the managed worktree lifecycle or produce a new worktree handoff. For worktree follow-up, focus the retained workspace and resume manually from its shell:
+`subagent_resume` rejects managed-worktree sessions. It does not reattach the managed worktree lifecycle or produce a new worktree handoff. For worktree follow-up, focus the retained workspace and resume manually from its shell:
 
 ```bash
 herdr workspace focus <workspace-id>

--- a/pi-extension/subagents/completion.ts
+++ b/pi-extension/subagents/completion.ts
@@ -86,7 +86,7 @@ function completionArtifact(
 	return consumeExitSidecar(options.sessionFile);
 }
 
-async function waitForDisappearanceArtifacts(
+async function waitForDelayedSidecar(
 	signal: AbortSignal,
 	options: CompletionOptions,
 ): Promise<CompletionResult | null> {
@@ -137,7 +137,15 @@ export async function waitForCompletion(
 
 		try {
 			const exitCode = terminalExitCode(await options.readTerminalTail());
-			if (exitCode !== null) return { reason: "sentinel", exitCode };
+			if (exitCode !== null) {
+				// The shell sentinel can become readable just before the child writes
+				// its authoritative error sidecar. Preserve that error metadata.
+				if (exitCode !== 0) {
+					const racedCompletion = await waitForDelayedSidecar(signal, options);
+					if (racedCompletion) return racedCompletion;
+				}
+				return { reason: "sentinel", exitCode };
+			}
 		} catch {
 			// Terminal reads are only sentinel/output probes; Herdr status is polled
 			// independently below, even when terminal reads succeed.
@@ -155,10 +163,7 @@ export async function waitForCompletion(
 			if (inspection.kind === "missing") {
 				// Pane closure and atomic artifact publication are separate operations.
 				// Allow a short bounded grace window before declaring evidence lost.
-				const racedCompletion = await waitForDisappearanceArtifacts(
-					signal,
-					options,
-				);
+				const racedCompletion = await waitForDelayedSidecar(signal, options);
 				if (racedCompletion) return racedCompletion;
 				return {
 					reason: "error",

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -385,15 +385,89 @@ function getBundledAgentsDir(): string {
 	return join(SUBAGENTS_DIR, "../../agents");
 }
 
+function getFrontmatterLines(frontmatter: string, key: string): string[] {
+	const prefix = `${key}:`;
+	return frontmatter
+		.split("\n")
+		.filter((candidate) => candidate.startsWith(prefix));
+}
+
 function getFrontmatterValue(
 	frontmatter: string,
 	key: string,
 ): string | undefined {
-	const prefix = `${key}:`;
-	const line = frontmatter
-		.split("\n")
-		.find((candidate) => candidate.startsWith(prefix));
-	return line?.slice(prefix.length).trim() || undefined;
+	const line = getFrontmatterLines(frontmatter, key)[0];
+	return line?.slice(`${key}:`.length).trim() || undefined;
+}
+
+interface CapabilityDeclarations {
+	canonical: string[];
+	hasNoncanonical: boolean;
+}
+
+function isCapabilityDeclaration(
+	line: string,
+	field: "tools" | "deny-tools" | "spawning",
+): boolean {
+	const trimmed = line.trimStart();
+	const colon = trimmed.indexOf(":");
+	if (colon === -1) return false;
+	const key = trimmed.slice(0, colon).trim();
+	return key === field || key === `"${field}"` || key === `'${field}'`;
+}
+
+function getCapabilityDeclarations(
+	frontmatter: string,
+	field: "tools" | "deny-tools" | "spawning",
+): CapabilityDeclarations {
+	const canonicalPrefix = `${field}:`;
+	const lines = frontmatter.split("\n");
+	return {
+		canonical: lines.filter((line) => line.startsWith(canonicalPrefix)),
+		hasNoncanonical: lines.some(
+			(line) =>
+				isCapabilityDeclaration(line, field) &&
+				!line.startsWith(canonicalPrefix),
+		),
+	};
+}
+
+function validateCapabilityDeclarations(
+	frontmatter: string,
+): string | undefined {
+	for (const field of ["tools", "deny-tools", "spawning"] as const) {
+		const declarations = getCapabilityDeclarations(frontmatter, field);
+		if (declarations.hasNoncanonical) {
+			return `${field} must use an unquoted, unindented key written exactly as ${field}:`;
+		}
+		if (declarations.canonical.length > 1) {
+			return `${field} may be declared only once.`;
+		}
+		if (declarations.canonical.length === 0) continue;
+
+		const value = declarations.canonical[0].slice(`${field}:`.length).trim();
+		if (field === "spawning") {
+			if (value !== "true" && value !== "false") {
+				return "spawning must be true or false.";
+			}
+			continue;
+		}
+
+		if (
+			!value ||
+			value.startsWith("[") ||
+			value.startsWith("{") ||
+			value.startsWith("|") ||
+			value.startsWith(">") ||
+			value.includes("#") ||
+			value.includes('"') ||
+			value.includes("'") ||
+			value.split(",").some((entry) => !entry.trim())
+		) {
+			return `${field} must use a non-empty comma-separated scalar; YAML lists and containers, comments and quotes are unsupported.`;
+		}
+	}
+	return undefined;
 }
 
 function parseOptionalBoolean(value: string | undefined): boolean | undefined {
@@ -456,6 +530,24 @@ function parseAgentDefinition(
 				frontmatter,
 				"disable-model-invocation",
 			)?.toLowerCase() === "true",
+	};
+}
+
+function invalidCapabilityDeclarationDiagnostic(
+	content: string,
+	agentName: string,
+	path: string,
+): AgentDiagnostic | null {
+	const match = content.match(/^---\n([\s\S]*?)\n---/);
+	if (!match) return null;
+	const resolvedAgentName = getFrontmatterValue(match[1], "name") ?? agentName;
+	const error = validateCapabilityDeclarations(match[1]);
+	if (!error) return null;
+	return {
+		code: "invalid-capability-declaration",
+		message: `Role "${resolvedAgentName}" has an invalid capability declaration in ${path}: ${error} Use documented comma-separated tools or deny-tools values, true or false for spawning, or omit the field.`,
+		path,
+		agentName: resolvedAgentName,
 	};
 }
 
@@ -571,6 +663,16 @@ function discoverAgentCatalog(
 				agents.delete(legacyDiagnostic.agentName ?? fallbackName);
 				continue;
 			}
+			const capabilityDiagnostic = invalidCapabilityDeclarationDiagnostic(
+				content,
+				fallbackName,
+				filePath,
+			);
+			if (capabilityDiagnostic) {
+				diagnostics.push(capabilityDiagnostic);
+				agents.delete(capabilityDiagnostic.agentName ?? fallbackName);
+				continue;
+			}
 			const parsed = parseAgentDefinition(content, fallbackName);
 			if (parsed)
 				agents.set(parsed.name, { ...parsed, source, path: filePath });
@@ -637,6 +739,18 @@ function discoverAgentCatalog(
 			);
 			if (legacyDiagnostic) {
 				diagnostics.push({ ...legacyDiagnostic, provider: metadata.provider });
+				continue;
+			}
+			const capabilityDiagnostic = invalidCapabilityDeclarationDiagnostic(
+				content,
+				fallbackName,
+				filePath,
+			);
+			if (capabilityDiagnostic) {
+				diagnostics.push({
+					...capabilityDiagnostic,
+					provider: metadata.provider,
+				});
 				continue;
 			}
 			const parsed = parseAgentDefinition(content, fallbackName);
@@ -3288,19 +3402,25 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 					};
 				}
 
-				const legacyRoleDiagnostic = params.agent
-					? discoverAgentCatalog(runtime.pi).diagnostics.find(
-							(candidate) =>
-								candidate.agentName === params.agent &&
-								candidate.code === "external-cli-unsupported",
-						)
+				const catalog = params.agent
+					? discoverAgentCatalog(runtime.pi)
 					: undefined;
-				if (legacyRoleDiagnostic) {
+				const roleDiagnostic =
+					catalog &&
+					!catalog.agents.some((agent) => agent.name === params.agent)
+						? catalog.diagnostics.find(
+								(candidate) =>
+									candidate.agentName === params.agent &&
+									(candidate.code === "external-cli-unsupported" ||
+										candidate.code === "invalid-capability-declaration"),
+							)
+						: undefined;
+				if (roleDiagnostic) {
 					return {
 						content: [
-							{ type: "text", text: `Error: ${legacyRoleDiagnostic.message}` },
+							{ type: "text", text: `Error: ${roleDiagnostic.message}` },
 						],
-						details: { error: legacyRoleDiagnostic.code },
+						details: { error: roleDiagnostic.code },
 					};
 				}
 

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -83,6 +83,7 @@ import {
 	findObservedSessionRuntime,
 	getNewEntries,
 	createBtwSessionSnapshot,
+	writeSubagentSessionPolicy,
 } from "./session.ts";
 import {
 	type SubagentStatusState,
@@ -2532,6 +2533,19 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 			if (childController.signal.aborted)
 				return workflowFailure("cancelled", "Workflow cancelled.");
 			mkdirSync(dirname(sessionFile), { recursive: true });
+			writeSubagentSessionPolicy(sessionFile, {
+				owner: "workflow",
+				tools: policy.tools,
+				deniedTools: [
+					"caller_ping",
+					"subagent_done",
+					"subagent",
+					"subagent_interrupt",
+					"subagent_resume",
+					"subagents_list",
+					"herdr_workflow",
+				],
+			});
 			surface = createSubagentPane(`${candidate.runId}: ${nodeId}`);
 			owner.children.set(id, { controller: childController, surface });
 			await waitForShellReady(surface, { signal: childController.signal });

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -1113,6 +1113,11 @@ function resolveUnexpectedErrorPresentation(
 	);
 }
 
+interface ModelFailure {
+	model: string;
+	error: string;
+}
+
 interface SubagentResultDetails {
 	name: string;
 	task?: string;
@@ -1123,6 +1128,7 @@ interface SubagentResultDetails {
 	error?: string;
 	errorMessage?: string;
 	fallbackAttempts?: string[];
+	fallbackFailures?: ModelFailure[];
 	worktree?: WorktreeHandoff;
 	runtimePlan?: ResolvedRuntimePlan;
 }
@@ -1245,6 +1251,8 @@ function resolveResultPresentation(
 		| "sessionFile"
 		| "errorMessage"
 		| "fallbackAttempts"
+		| "fallbackFailures"
+		| "runtimePlan"
 		| "worktree"
 	>,
 	name: string,
@@ -1252,18 +1260,26 @@ function resolveResultPresentation(
 ): string {
 	const sessionRef = formatSessionReference(result.sessionFile);
 	let body: string;
+	const attempted = result.fallbackAttempts ?? [];
+	const requestedModel =
+		attempted[0] ??
+		result.runtimePlan?.requestedModel ??
+		result.runtimePlan?.model;
+	const usedModel =
+		result.runtimePlan?.observed?.model ?? result.runtimePlan?.model;
 
 	if (result.errorMessage) {
-		// Auto-retry exhausted or other agent-loop error. The subagent did not
-		// produce a usable result — surface the underlying provider/network
-		// failure so the orchestrator can decide whether to retry, resume, or
-		// change approach instead of silently treating the run as completed.
+		// Pi owns provider retry policy and exposes the settled error as text. Do
+		// not infer retry counts or permanence from that text; preserve it as-is.
 		body =
 			`Sub-agent "${name}" failed after ${formatElapsed(result.elapsed)} ` +
-			`(provider/agent error — auto-retry exhausted).\n\n` +
+			`(provider/agent error).\n\n` +
 			`Error: ${result.errorMessage}\n\n` +
-			`The subagent did not produce a result. You can retry by spawning a new ` +
-			`subagent or resume the session with subagent_resume.`;
+			`The subagent did not produce a result. Next action: check the raw ` +
+			`provider reason and verify model access for this account. Spawn a new ` +
+			`subagent with a supported model or configured fallback; use ` +
+			`subagent_resume only after resolving access for this session's stored ` +
+			`model because resume does not select a model.`;
 	} else {
 		body =
 			result.exitCode === 0
@@ -1271,8 +1287,16 @@ function resolveResultPresentation(
 				: `Sub-agent "${name}" failed (exit code ${result.exitCode}).\n\n${result.summary}`;
 	}
 
-	if (result.fallbackAttempts && result.fallbackAttempts.length > 1) {
-		body += `\n\nModels attempted: ${result.fallbackAttempts.join(", ")}`;
+	if (requestedModel) body += `\n\nRequested model: ${requestedModel}`;
+	if (attempted.length > 1)
+		body += `\nModels attempted: ${attempted.join(", ")}`;
+	if (usedModel) body += `\nModel used: ${usedModel}`;
+	if (result.fallbackFailures?.length) {
+		body +=
+			"\nModel failures (raw errors, in attempt order):" +
+			result.fallbackFailures
+				.map(({ model, error }) => `\n- ${model}: ${error}`)
+				.join("");
 	}
 	if (result.worktree) body += `\n\n${formatWorktreeHandoff(result.worktree)}`;
 	const runtimeWarning = runtimeMismatch
@@ -1292,12 +1316,15 @@ interface SubagentResult {
 	exitCode: number;
 	elapsed: number;
 	error?: string;
-	/** Provider/agent error message when auto-retry exhausted (overload, rate limit, etc.). */
+	/** Settled provider/agent error text from the child, preserved verbatim. */
 	errorMessage?: string;
 	/** Ordered models launched for this run, including failed fallback attempts. */
 	fallbackAttempts?: string[];
+	/** Ordered raw errors associated with failed model attempts. */
+	fallbackFailures?: ModelFailure[];
 	ping?: { name: string; message: string };
 	worktree?: WorktreeHandoff;
+	runtimePlan?: ResolvedRuntimePlan;
 }
 
 /**
@@ -2038,6 +2065,7 @@ export const __test__ = {
 	handleSubagentInterrupt,
 	resolveResultPresentation,
 	resolveUnexpectedErrorPresentation,
+	shouldAdvanceToFallback,
 	sendSubagentResult,
 	shouldRetainSubagentSurface,
 	resolveWorktreeLaunchWarning,
@@ -2220,8 +2248,12 @@ async function launchSubagentWithFallbacks(
 	ctx: Parameters<typeof launchSubagent>[1],
 	parentThinking: ThinkingLevel,
 	plans: ResolvedRuntimePlan[],
-): Promise<{ running: RunningSubagent; index: number }> {
-	const failures: string[] = [];
+): Promise<{
+	running: RunningSubagent;
+	index: number;
+	launchFailures: ModelFailure[];
+}> {
+	const launchFailures: ModelFailure[] = [];
 	for (const [index, plan] of plans.entries()) {
 		try {
 			return {
@@ -2229,15 +2261,17 @@ async function launchSubagentWithFallbacks(
 					runtimePlan: plan,
 				}),
 				index,
+				launchFailures,
 			};
 		} catch (error) {
-			failures.push(
-				`${plan.model}: ${error instanceof Error ? error.message : String(error)}`,
-			);
+			launchFailures.push({
+				model: plan.model,
+				error: error instanceof Error ? error.message : String(error),
+			});
 		}
 	}
 	throw new Error(
-		`Subagent could not launch with any configured model. Attempted: ${plans.map((plan) => plan.model).join(", ")}. ${failures.join("; ")}`,
+		`Subagent could not launch with any configured model. Attempted: ${plans.map((plan) => plan.model).join(", ")}. ${launchFailures.map(({ model, error }) => `${model}: ${error}`).join("; ")}`,
 	);
 }
 
@@ -2344,6 +2378,7 @@ async function watchSubagent(
 			exitCode: result.exitCode,
 			elapsed,
 			ping: result.ping,
+			runtimePlan: running.runtimePlan,
 		};
 		if (result.errorMessage) watchResult.errorMessage = result.errorMessage;
 		if (worktreeHandoff) watchResult.worktree = worktreeHandoff;
@@ -2384,6 +2419,13 @@ async function watchSubagent(
 	}
 }
 
+export function shouldAdvanceToFallback(
+	result: Pick<SubagentResult, "errorMessage">,
+	remainingPlans: number,
+): boolean {
+	return !!result.errorMessage && remainingPlans > 0;
+}
+
 async function watchSubagentWithFallbacks(
 	initial: RunningSubagent,
 	initialPlanIndex: number,
@@ -2392,23 +2434,41 @@ async function watchSubagentWithFallbacks(
 	parentThinking: ThinkingLevel,
 	plans: ResolvedRuntimePlan[],
 	signal: AbortSignal,
+	initialLaunchFailures: ModelFailure[] = [],
 ): Promise<{ running: RunningSubagent; result: SubagentResult }> {
 	let running = initial;
 	let nextPlan = initialPlanIndex + 1;
-	const attempts = [running.runtimePlan?.model].filter(
-		(model): model is string => !!model,
-	);
+	const attempts = plans
+		.slice(0, initialPlanIndex + 1)
+		.map((plan) => plan.model);
+	const modelFailures = [...initialLaunchFailures];
 
 	for (;;) {
 		const result = await watchSubagent(running, signal);
-		const shouldRetry = !!result.errorMessage && nextPlan < plans.length;
+		const shouldRetry = shouldAdvanceToFallback(
+			result,
+			plans.length - nextPlan,
+		);
+		if (result.errorMessage) {
+			modelFailures.push({
+				model: running.runtimePlan?.model ?? attempts[attempts.length - 1],
+				error: result.errorMessage,
+			});
+		}
 		if (!shouldRetry) {
-			return { running, result: { ...result, fallbackAttempts: attempts } };
+			return {
+				running,
+				result: {
+					...result,
+					fallbackAttempts: attempts,
+					fallbackFailures: modelFailures,
+				},
+			};
 		}
 
 		runningSubagents.delete(running.id);
 		updateWidget();
-		const launchErrors: string[] = [];
+		const launchFailures: ModelFailure[] = [];
 		let launchedFallback = false;
 		while (nextPlan < plans.length) {
 			const plan = plans[nextPlan++];
@@ -2424,18 +2484,21 @@ async function watchSubagentWithFallbacks(
 				startStatusRefresh(runtime.pi!);
 				break;
 			} catch (error) {
-				launchErrors.push(
-					`${plan.model}: ${error instanceof Error ? error.message : String(error)}`,
-				);
+				launchFailures.push({
+					model: plan.model,
+					error: error instanceof Error ? error.message : String(error),
+				});
 			}
 		}
+		modelFailures.push(...launchFailures);
 		if (!launchedFallback) {
 			return {
 				running,
 				result: {
 					...result,
-					errorMessage: `${result.errorMessage}\n\nFallback launch failures: ${launchErrors.join("; ")}`,
+					errorMessage: `${result.errorMessage}\n\nFallback launch failures: ${launchFailures.map(({ model, error }) => `${model}: ${error}`).join("; ")}`,
 					fallbackAttempts: attempts,
+					fallbackFailures: modelFailures,
 				},
 			};
 		}
@@ -3465,13 +3528,16 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 					params,
 					runtime.pi,
 				);
-				const { running, index: initialPlanIndex } =
-					await launchSubagentWithFallbacks(
-						params,
-						ctx,
-						parentThinking,
-						runtimePlans,
-					);
+				const {
+					running,
+					index: initialPlanIndex,
+					launchFailures: initialLaunchFailures,
+				} = await launchSubagentWithFallbacks(
+					params,
+					ctx,
+					parentThinking,
+					runtimePlans,
+				);
 
 				// Create a separate AbortController for the watcher
 				// (the tool's signal completes when we return)
@@ -3491,6 +3557,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 					parentThinking,
 					runtimePlans,
 					watcherAbort.signal,
+					initialLaunchFailures,
 				)
 					.then(({ running: completedRunning, result }) => {
 						if (!shouldDeliverSubagentCompletion(completedRunning)) {
@@ -3553,6 +3620,8 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 							resultDetails.errorMessage = result.errorMessage;
 						if (result.fallbackAttempts)
 							resultDetails.fallbackAttempts = result.fallbackAttempts;
+						if (result.fallbackFailures)
+							resultDetails.fallbackFailures = result.fallbackFailures;
 						if (result.worktree) resultDetails.worktree = result.worktree;
 						if (completedRunning.runtimePlan)
 							resultDetails.runtimePlan = completedRunning.runtimePlan;
@@ -4370,7 +4439,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 					)
 					.replace(
 						new RegExp(
-							`^Sub-agent "${name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}" failed after ${elapsed} \\(provider/agent error — auto-retry exhausted\\)\\.\\n\\n`,
+							`^Sub-agent "${name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}" failed after ${elapsed} \\(provider/agent error\\)\\.\\n\\n`,
 						),
 						"",
 					);

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -67,6 +67,7 @@ import {
 	recoverWorkflowStartup,
 	sameWorkflowCandidate,
 	validateWorkflowApproval,
+	type CancelTerminationResult,
 	type PendingWorkflow,
 	type WorkflowReaderCheckout,
 	type WorkflowRole,
@@ -1239,6 +1240,7 @@ interface WorkflowOwner {
 	checkout?: string;
 	journal?: ReturnType<typeof createWorkflowJournal>;
 	cancelPromise?: Promise<WorkflowTerminalOutcome>;
+	termination?: CancelTerminationResult;
 }
 
 interface WorkflowCancelHooks {
@@ -2713,6 +2715,118 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 			runtime.activeWorkflow = undefined;
 		return outcome;
 	};
+	const terminateWorkflowChildren = async (
+		owner: WorkflowOwner,
+		options: WorkflowCancelHooks = {},
+	): Promise<CancelTerminationResult> => {
+		const hooks = { ...runtime.workflowCancelHooks, ...options };
+		const getProcessInfo = hooks.getProcessInfo ?? getPaneProcessInfo;
+		const closeSurface = hooks.closeSurface ?? closePane;
+		const waitAbsence = hooks.waitAbsence ?? waitForPaneAbsence;
+		const waitExit = hooks.waitExit ?? waitForProcessesExit;
+		try {
+			owner.controller.abort();
+			const children = [...owner.children.values()];
+			const captured: Array<{
+				surface?: string;
+				pids: number[];
+				identityUnconfirmed: boolean;
+			}> = [];
+			for (const child of children) {
+				child.controller.abort();
+				const pids: number[] = [];
+				let identityUnconfirmed = false;
+				if (child.surface) {
+					try {
+						const info = getProcessInfo(child.surface);
+						pids.push(...info.pids);
+						owner.journal?.append("cancel_process_info", {
+							surface: child.surface,
+							pids: info.pids,
+						});
+						if (info.pids.length === 0) identityUnconfirmed = true;
+					} catch (error) {
+						identityUnconfirmed = true;
+						owner.journal?.append("cancel_process_info_failed", {
+							surface: child.surface,
+							error: error instanceof Error ? error.message : String(error),
+						});
+					}
+				}
+				captured.push({
+					surface: child.surface,
+					pids,
+					identityUnconfirmed,
+				});
+			}
+			for (const child of captured) {
+				if (!child.surface) continue;
+				try {
+					closeSurface(child.surface);
+				} catch (error) {
+					owner.journal?.append("pane_close_failed", {
+						surface: child.surface,
+						error: error instanceof Error ? error.message : String(error),
+					});
+				}
+			}
+			const surviving: number[] = [];
+			let identityUnconfirmed = false;
+			for (const child of captured) {
+				if (child.identityUnconfirmed) identityUnconfirmed = true;
+				if (child.surface) {
+					const gone = await waitAbsence(child.surface, {
+						timeoutMs: 5_000,
+						intervalMs: 50,
+					});
+					if (!gone) {
+						identityUnconfirmed = true;
+						owner.journal?.append("cancel_pane_still_present", {
+							surface: child.surface,
+						});
+					}
+				}
+				if (child.pids.length > 0) {
+					surviving.push(
+						...(await waitExit(child.pids, {
+							timeoutMs: 5_000,
+							intervalMs: 50,
+						})),
+					);
+				}
+			}
+			const uniqueSurvivors = [...new Set(surviving)];
+			const termination = cancelTerminationResult(
+				uniqueSurvivors,
+				owner.checkout,
+				{ identityUnconfirmed },
+			);
+			if (termination.retainCheckout && owner.checkout) {
+				owner.journal?.append("reader_checkout_retained", {
+					path: owner.checkout,
+					reason: "cancel_termination_failed",
+					survivingPids: uniqueSurvivors,
+					identityUnconfirmed,
+				});
+			}
+			owner.termination = termination;
+			return termination;
+		} catch (error) {
+			const termination = cancelTerminationResult([], owner.checkout, {
+				identityUnconfirmed: true,
+			});
+			termination.outcome.error!.message =
+				error instanceof Error ? error.message : String(error);
+			if (owner.checkout) {
+				owner.journal?.append("reader_checkout_retained", {
+					path: owner.checkout,
+					reason: "cancel_termination_failed",
+				});
+			}
+			owner.termination = termination;
+			return termination;
+		}
+	};
 	const cancelWorkflow = async (
 		owner: WorkflowOwner,
 		options: WorkflowCancelHooks = {},
@@ -2748,127 +2862,23 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 		});
 		owner.cancelPromise = deferred;
 
-		const hooks = { ...runtime.workflowCancelHooks, ...options };
-		const getProcessInfo = hooks.getProcessInfo ?? getPaneProcessInfo;
-		const closeSurface = hooks.closeSurface ?? closePane;
-		const waitAbsence = hooks.waitAbsence ?? waitForPaneAbsence;
-		const waitExit = hooks.waitExit ?? waitForProcessesExit;
 		void (async () => {
-			try {
-				owner.controller.abort();
-				const children = [...owner.children.values()];
-				const captured: Array<{
-					surface?: string;
-					pids: number[];
-					identityUnconfirmed: boolean;
-				}> = [];
-				for (const child of children) {
-					child.controller.abort();
-					const pids: number[] = [];
-					let identityUnconfirmed = false;
-					if (child.surface) {
-						try {
-							const info = getProcessInfo(child.surface);
-							pids.push(...info.pids);
-							owner.journal?.append("cancel_process_info", {
-								surface: child.surface,
-								pids: info.pids,
-								shellPid: info.shellPid,
-								foregroundProcessGroupId: info.foregroundProcessGroupId,
-							});
-							// Active panes with no waitable PIDs lack exit proof.
-							if (info.pids.length === 0) identityUnconfirmed = true;
-						} catch (error) {
-							identityUnconfirmed = true;
-							owner.journal?.append("cancel_process_info_failed", {
-								surface: child.surface,
-								error: error instanceof Error ? error.message : String(error),
-							});
-						}
-					}
-					captured.push({
-						surface: child.surface,
-						pids,
-						identityUnconfirmed,
-					});
-				}
-				for (const child of captured) {
-					if (!child.surface) continue;
-					try {
-						closeSurface(child.surface);
-					} catch (error) {
-						owner.journal?.append("pane_close_failed", {
-							surface: child.surface,
-							error: error instanceof Error ? error.message : String(error),
-						});
-					}
-				}
-				const surviving: number[] = [];
-				let identityUnconfirmed = false;
-				for (const child of captured) {
-					if (child.identityUnconfirmed) identityUnconfirmed = true;
-					if (child.surface) {
-						const gone = await waitAbsence(child.surface, {
-							timeoutMs: 5_000,
-							intervalMs: 50,
-						});
-						if (!gone) {
-							// Pane still present after close: treat as unconfirmed termination.
-							identityUnconfirmed = true;
-							owner.journal?.append("cancel_pane_still_present", {
-								surface: child.surface,
-							});
-						}
-					}
-					if (child.pids.length > 0) {
-						surviving.push(
-							...(await waitExit(child.pids, {
-								timeoutMs: 5_000,
-								intervalMs: 50,
-							})),
-						);
-					}
-				}
-				const uniqueSurvivors = [...new Set(surviving)];
-				const termination = cancelTerminationResult(
-					uniqueSurvivors,
-					owner.checkout,
-					{ identityUnconfirmed },
-				);
-				let checkoutResult: WorkflowReaderCheckout | undefined =
-					termination.checkout;
-				if (termination.retainCheckout) {
-					if (owner.checkout) {
-						owner.journal?.append("reader_checkout_retained", {
-							path: owner.checkout,
-							reason: "cancel_termination_failed",
-							survivingPids: uniqueSurvivors,
-							identityUnconfirmed,
-						});
-					}
-					settle(finalizeWorkflow(owner, termination.outcome, checkoutResult));
-					return;
-				}
-				if (owner.checkout && owner.journal) {
-					checkoutResult = disposeWorkflowReaderCheckout(
-						owner.candidate,
-						owner.checkout,
-						owner.journal,
-					);
-					owner.checkout = undefined;
-				}
+			const termination = await terminateWorkflowChildren(owner, options);
+			let checkoutResult: WorkflowReaderCheckout | undefined =
+				termination.checkout;
+			if (termination.retainCheckout) {
 				settle(finalizeWorkflow(owner, termination.outcome, checkoutResult));
-			} catch (error) {
-				settle(
-					finalizeWorkflow(owner, {
-						state: "failed",
-						error: {
-							code: "cancel_termination_failed",
-							message: error instanceof Error ? error.message : String(error),
-						},
-					}),
-				);
+				return;
 			}
+			if (owner.checkout && owner.journal) {
+				checkoutResult = disposeWorkflowReaderCheckout(
+					owner.candidate,
+					owner.checkout,
+					owner.journal,
+				);
+				owner.checkout = undefined;
+			}
+			settle(finalizeWorkflow(owner, termination.outcome, checkoutResult));
 		})();
 		return deferred;
 	};
@@ -2889,6 +2899,16 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 					owner.worker = worker;
 				},
 				onLog: (message) => journal.append("workflow_log", { message }),
+				onTerminal: async () => {
+					if (owner.gate.phase !== "running") {
+						if (owner.cancelPromise) await owner.cancelPromise;
+						return undefined;
+					}
+					const termination = await terminateWorkflowChildren(owner);
+					return termination.retainCheckout
+						? { state: "failed" as const, error: termination.outcome.error! }
+						: undefined;
+				},
 				onAgent: async (prompt, options) => {
 					const result = await runWorkflowAgent(
 						owner,
@@ -2920,7 +2940,11 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 			if (owner.cancelPromise) await owner.cancelPromise;
 			return;
 		}
-		let checkoutResult: WorkflowReaderCheckout | undefined;
+		let checkoutResult = owner.termination?.checkout;
+		if (owner.termination?.retainCheckout) {
+			finalizeWorkflow(owner, execution, checkoutResult);
+			return;
+		}
 		if (owner.checkout) {
 			checkoutResult = disposeWorkflowReaderCheckout(
 				candidate,

--- a/pi-extension/subagents/launch.ts
+++ b/pi-extension/subagents/launch.ts
@@ -17,7 +17,9 @@ import { HerdrWorktreeCreateError } from "./herdr.ts";
 import type { JsonObject } from "./type-guards.ts";
 import {
 	createWorktreeSessionFork,
+	readSubagentSessionPolicy,
 	seedSubagentSessionFile,
+	writeSubagentSessionPolicy,
 } from "./session.ts";
 import {
 	closePane,
@@ -452,6 +454,11 @@ function prepareChildSession(
 		surface.worktree.sessionFile = sessionFile;
 		writeWorktreeManifest(surface.worktree.manifestFile, { sessionFile });
 	}
+	writeSubagentSessionPolicy(sessionFile, {
+		owner: surface.worktree ? "managed-worktree" : "public",
+		tools: resolved.request.behavior.tools,
+		deniedTools: resolved.request.behavior.deniedTools,
+	});
 	const activityFile = getSubagentActivityFile(
 		resolved.artifactDir,
 		resolved.id,
@@ -686,6 +693,13 @@ async function launchResumedPiSubagent(
 	operations: PiLaunchOperations,
 ): Promise<PiRunningChild> {
 	const id = request.id ?? Math.random().toString(16).slice(2, 10);
+	const policy = readSubagentSessionPolicy(request.sessionFile);
+	if (policy.owner !== "public") {
+		throw new Error(
+			`Cannot resume ${policy.owner} session through subagent_resume. ` +
+				"Use its retained workspace or workflow evidence instead.",
+		);
+	}
 	const autoExit = request.behavior?.autoExit ?? true;
 	const interactive = request.behavior?.interactive ?? !autoExit;
 	const startTime = Date.now();
@@ -715,17 +729,25 @@ async function launchResumedPiSubagent(
 			...(process.env.PI_CODING_AGENT_DIR
 				? [`PI_CODING_AGENT_DIR=${shellQuote(process.env.PI_CODING_AGENT_DIR)}`]
 				: []),
+			...(policy.deniedTools.length > 0
+				? [`PI_DENY_TOOLS=${shellQuote(policy.deniedTools.join(","))}`]
+				: []),
 			`PI_SUBAGENT_NAME=${shellQuote(request.name)}`,
 			`PI_SUBAGENT_SESSION=${shellQuote(request.sessionFile)}`,
 			`PI_SUBAGENT_ID=${shellQuote(id)}`,
 			`PI_SUBAGENT_ACTIVITY_FILE=${shellQuote(activityFile)}`,
 			`PI_SUBAGENT_AUTO_EXIT=${autoExit ? "1" : "0"}`,
 		];
+		const toolAllowlist = buildSubagentToolAllowlist(
+			policy.tools?.join(","),
+			autoExit,
+		);
 		const command = [
 			...env,
 			"pi",
 			"--session",
 			shellQuote(request.sessionFile),
+			...(toolAllowlist ? ["--tools", shellQuote(toolAllowlist)] : []),
 			"-e",
 			shellQuote(join(SUBAGENTS_DIR, "subagent-done.ts")),
 			...(messageFile ? [shellQuote(`@${messageFile}`)] : []),

--- a/pi-extension/subagents/session.ts
+++ b/pi-extension/subagents/session.ts
@@ -10,7 +10,12 @@ import {
 } from "node:fs";
 import { randomBytes, randomUUID } from "node:crypto";
 import { dirname, join } from "node:path";
-import { isString, type JsonValue } from "./type-guards.ts";
+import {
+	isPlainObject,
+	isString,
+	type JsonObject,
+	type JsonValue,
+} from "./type-guards.ts";
 
 export interface SessionEntry {
 	type: string;
@@ -39,6 +44,152 @@ export interface WorktreeSessionFork {
 	sessionFile: string;
 	sourceSessionFile: string;
 	handoffMessage: string;
+}
+
+const SUBAGENT_POLICY_VERSION = 1;
+const SUBAGENT_POLICY_SUFFIX = ".pi-herdr-subagent-policy.json";
+
+export type SubagentSessionOwner = "public" | "managed-worktree" | "workflow";
+
+export interface SubagentSessionPolicy {
+	version: 1;
+	owner: SubagentSessionOwner;
+	/** null deliberately means Pi's unrestricted default tool selection. */
+	tools: string[] | null;
+	deniedTools: string[];
+}
+
+export function getSubagentSessionPolicyFile(sessionFile: string): string {
+	return `${sessionFile}${SUBAGENT_POLICY_SUFFIX}`;
+}
+
+function normalizePolicyToolNames(
+	tools: string | readonly string[] | undefined,
+): string[] | null {
+	const values = isString(tools)
+		? tools.split(",")
+		: tools === undefined
+			? []
+			: [...tools];
+	const normalized = [
+		...new Set(values.map((tool) => tool.trim()).filter(Boolean)),
+	];
+	return normalized.length > 0 ? normalized : null;
+}
+
+export function writeSubagentSessionPolicy(
+	sessionFile: string,
+	policy: Omit<SubagentSessionPolicy, "version" | "tools" | "deniedTools"> & {
+		tools?: string | readonly string[];
+		deniedTools: readonly string[];
+	},
+): void {
+	const value: SubagentSessionPolicy = {
+		version: SUBAGENT_POLICY_VERSION,
+		owner: policy.owner,
+		tools: normalizePolicyToolNames(policy.tools),
+		deniedTools: normalizePolicyToolNames(policy.deniedTools) ?? [],
+	};
+	writeFileSync(
+		getSubagentSessionPolicyFile(sessionFile),
+		`${JSON.stringify(value)}\n`,
+		"utf8",
+	);
+}
+
+function policyError(sessionFile: string, reason: string): Error {
+	return new Error(
+		`Cannot safely resume ${sessionFile}: ${reason}. ` +
+			"Start a new subagent with the required restrictions, or manually resume it only after choosing an explicit Pi tool policy.",
+	);
+}
+
+function isPolicyRecord(value: JsonValue): value is JsonObject {
+	return isPlainObject(value);
+}
+
+export function readSubagentSessionPolicy(
+	sessionFile: string,
+): SubagentSessionPolicy {
+	const path = getSubagentSessionPolicyFile(sessionFile);
+	let value: JsonValue;
+	try {
+		value = JSON.parse(readFileSync(path, "utf8"));
+	} catch (error) {
+		const reason =
+			error instanceof Error && "code" in error && error.code === "ENOENT"
+				? "the saved launch policy is missing"
+				: "the saved launch policy cannot be read";
+		throw policyError(sessionFile, reason);
+	}
+	if (!isPolicyRecord(value))
+		throw policyError(sessionFile, "the saved launch policy is malformed");
+	const expected = new Set(["version", "owner", "tools", "deniedTools"]);
+	if (Object.keys(value).some((key) => !expected.has(key))) {
+		throw policyError(
+			sessionFile,
+			"the saved launch policy has unsupported fields",
+		);
+	}
+	if (value.version !== SUBAGENT_POLICY_VERSION) {
+		throw policyError(
+			sessionFile,
+			"the saved launch policy version is unsupported",
+		);
+	}
+	const owner = value.owner;
+	if (
+		owner !== "public" &&
+		owner !== "managed-worktree" &&
+		owner !== "workflow"
+	) {
+		throw policyError(sessionFile, "the saved launch policy owner is invalid");
+	}
+	const validateTools = (
+		tools: JsonValue | undefined,
+		allowNull: boolean,
+		allowEmpty: boolean,
+	): string[] | null => {
+		if (tools === null) {
+			if (allowNull) return null;
+			throw policyError(
+				sessionFile,
+				"the saved denied-tool policy is malformed",
+			);
+		}
+		if (!Array.isArray(tools)) {
+			throw policyError(
+				sessionFile,
+				"the saved launch tool policy is malformed",
+			);
+		}
+		const names: string[] = [];
+		for (const tool of tools) {
+			if (!isString(tool) || tool === "" || /[,\s]/.test(tool)) {
+				throw policyError(
+					sessionFile,
+					"the saved launch tool policy is malformed",
+				);
+			}
+			names.push(tool);
+		}
+		if (
+			(!allowEmpty && names.length === 0) ||
+			new Set(names).size !== names.length
+		) {
+			throw policyError(
+				sessionFile,
+				"the saved launch tool policy is malformed",
+			);
+		}
+		return names;
+	};
+	const tools = validateTools(value.tools, true, false);
+	const deniedTools = validateTools(value.deniedTools, false, true);
+	if (deniedTools === null) {
+		throw policyError(sessionFile, "the saved denied-tool policy is malformed");
+	}
+	return { version: 1, owner, tools, deniedTools };
 }
 
 function getForkContentLines(parentSessionFile: string): string[] {

--- a/pi-extension/subagents/workflow.ts
+++ b/pi-extension/subagents/workflow.ts
@@ -1000,6 +1000,12 @@ export async function executeWorkflow(
 		onLog?: (message: string) => void;
 		onWorker?: (worker: Worker) => void;
 		onAgent?: (prompt: string, options: any) => JsonValue | Promise<JsonValue>;
+		onTerminal?: (
+			outcome: WorkflowExecutionResult,
+		) =>
+			| WorkflowExecutionResult
+			| undefined
+			| Promise<void | WorkflowExecutionResult | undefined>;
 	} = {},
 ): Promise<WorkflowExecutionResult> {
 	return new Promise((resolve) => {
@@ -1015,6 +1021,7 @@ export async function executeWorkflow(
 		let agents = 0;
 		let activeAgents = 0;
 		const agentQueue: Array<(forced?: JsonValue) => void> = [];
+		const activeAgentOperations = new Set<Promise<void>>();
 		const drainQueue = (result: JsonValue = CANCELLED_AGENT_RESULT) => {
 			const queued = agentQueue.splice(0);
 			for (const start of queued) start(result);
@@ -1026,12 +1033,13 @@ export async function executeWorkflow(
 						resolveAgent(forced);
 						return;
 					}
-					if (options.signal?.aborted) {
+					if (settled || options.signal?.aborted) {
 						resolveAgent(CANCELLED_AGENT_RESULT);
 						return;
 					}
 					activeAgents += 1;
-					void (async () => {
+					let operation!: Promise<void>;
+					operation = (async () => {
 						try {
 							const result = await options.onAgent?.(prompt, agentOptions);
 							resolveAgent(
@@ -1052,10 +1060,12 @@ export async function executeWorkflow(
 							});
 						} finally {
 							activeAgents -= 1;
+							activeAgentOperations.delete(operation);
 							const next = agentQueue.shift();
 							if (next) next();
 						}
 					})();
+					activeAgentOperations.add(operation);
 				};
 				if (options.signal?.aborted) {
 					resolveAgent(CANCELLED_AGENT_RESULT);
@@ -1070,7 +1080,24 @@ export async function executeWorkflow(
 			clearTimeout(deadline);
 			options.signal?.removeEventListener("abort", onAbort);
 			drainQueue();
-			void worker.terminate().finally(() => resolve(result));
+			void (async () => {
+				let finalResult = result;
+				try {
+					await worker.terminate();
+					const terminalResult = await options.onTerminal?.(result);
+					if (terminalResult) finalResult = terminalResult;
+					await Promise.allSettled(activeAgentOperations);
+				} catch (error) {
+					finalResult = {
+						state: "failed",
+						error: {
+							code: "workflow_terminal_error",
+							message: error instanceof Error ? error.message : String(error),
+						},
+					};
+				}
+				resolve(finalResult);
+			})();
 		};
 		const fail = (code: string, message: string) =>
 			finish({ state: "failed", error: { code, message } });

--- a/test/integration/agents/test-restricted.md
+++ b/test/integration/agents/test-restricted.md
@@ -1,0 +1,11 @@
+---
+name: test-restricted
+description: Integration test agent with one read-only tool and no spawning
+model: openrouter/free
+tools: read
+spawning: false
+auto-exit: true
+disable-model-invocation: true
+---
+
+Return the requested marker without using tools.

--- a/test/integration/fake-provider.ts
+++ b/test/integration/fake-provider.ts
@@ -56,9 +56,12 @@ export const TEST_MODEL = "pi-integration/test";
 export interface ProviderRequest {
 	model?: string;
 	status: number;
+	tools?: string[];
+	lastUser?: string;
 }
 
 const providerRequests: ProviderRequest[] = [];
+const resumeRestrictionStates = new Map<string, "launched" | "resumed">();
 
 export function getProviderRequests(): readonly ProviderRequest[] {
 	return providerRequests;
@@ -66,6 +69,7 @@ export function getProviderRequests(): readonly ProviderRequest[] {
 
 export function resetProviderRequests(): void {
 	providerRequests.length = 0;
+	resumeRestrictionStates.clear();
 }
 
 async function readJson(request: IncomingMessage): Promise<ChatRequest> {
@@ -198,6 +202,64 @@ function btwText(source: string): string | undefined {
 	return undefined;
 }
 
+function resumeRestrictionResponse(request: ChatRequest): ResponsePlan | null {
+	const names = toolNames(request);
+	const source = requestText(request);
+	const user = lastUserText(request);
+	const id = source.match(
+		/INTEGRATION_RESUME_RESTRICTIONS:([A-Za-z0-9_-]+)/,
+	)?.[1];
+	if (!id) return null;
+
+	if (!names.has("subagent") && !names.has("subagent_resume")) {
+		if (user.includes(`RESUME_RESTRICTED_${id}`)) {
+			return names.has("read") &&
+				!names.has("subagent") &&
+				!names.has("subagent_resume")
+				? { text: `RESTRICTED_RESUME_${id}` }
+				: { text: `RESTRICTED_TOOL_LEAK_${id}` };
+		}
+		return { text: `RESTRICTED_FIRST_${id}` };
+	}
+
+	const state = resumeRestrictionStates.get(id);
+	if (state === "resumed") {
+		return { text: `RESUME_RESTRICTIONS_COMPLETE_${id}` };
+	}
+	if (state === "launched") {
+		const sessionPath = source.match(/Session:\s*(\S+\.jsonl)/)?.[1];
+		if (source.includes(`RESTRICTED_FIRST_${id}`) && sessionPath) {
+			resumeRestrictionStates.set(id, "resumed");
+			return {
+				toolCalls: [
+					{
+						name: "subagent_resume",
+						arguments: {
+							sessionPath,
+							name: `Restricted-${id}`,
+							message: `RESUME_RESTRICTED_${id}`,
+						},
+					},
+				],
+			};
+		}
+		return { text: `WAITING_FOR_RESTRICTED_RESULT_${id}` };
+	}
+	resumeRestrictionStates.set(id, "launched");
+	return {
+		toolCalls: [
+			{
+				name: "subagent",
+				arguments: {
+					name: `Restricted-${id}`,
+					agent: "test-restricted",
+					task: `INTEGRATION_RESUME_RESTRICTIONS:${id} Return exactly RESTRICTED_FIRST_${id}`,
+				},
+			},
+		],
+	};
+}
+
 function multiWaveCoordinatorResponse(
 	request: ChatRequest,
 ): ResponsePlan | null {
@@ -267,6 +329,9 @@ async function planResponse(request: ChatRequest): Promise<ResponsePlan> {
 	const source = requestText(request);
 	const user = lastUserText(request);
 	const lastRole = request.messages?.at(-1)?.role;
+
+	const resumeRestriction = resumeRestrictionResponse(request);
+	if (resumeRestriction) return resumeRestriction;
 
 	const multiWave = multiWaveCoordinatorResponse(request);
 	if (multiWave) return multiWave;
@@ -513,7 +578,12 @@ const server = createServer(async (request, response) => {
 			);
 			return;
 		}
-		providerRequests.push({ model: chatRequest.model, status: 200 });
+		providerRequests.push({
+			model: chatRequest.model,
+			status: 200,
+			tools: [...toolNames(chatRequest)].sort(),
+			lastUser: lastUserText(chatRequest),
+		});
 		writeResponse(response, chatRequest, await planResponse(chatRequest));
 	} catch (error) {
 		providerRequests.push({ status: 500 });

--- a/test/integration/fake-provider.ts
+++ b/test/integration/fake-provider.ts
@@ -565,6 +565,19 @@ const server = createServer(async (request, response) => {
 	}
 	try {
 		const chatRequest = await readJson(request);
+		if (chatRequest.model === "account-rejected") {
+			providerRequests.push({ model: chatRequest.model, status: 400 });
+			response.writeHead(400, { "content-type": "application/json" });
+			response.end(
+				JSON.stringify({
+					error: {
+						message:
+							"The 'account-rejected' model is not supported when using this account.",
+					},
+				}),
+			);
+			return;
+		}
 		if (
 			chatRequest.model === "fallback-primary" ||
 			chatRequest.model === "fallback-fail"

--- a/test/integration/harness.ts
+++ b/test/integration/harness.ts
@@ -193,6 +193,7 @@ function writeTestProviderConfig(agentDir: string): void {
 							"fallback-primary",
 							"fallback-secondary",
 							"fallback-fail",
+							"account-rejected",
 						].map((id) => ({
 							id,
 							name: "Deterministic integration test model",

--- a/test/integration/mux-surface.test.ts
+++ b/test/integration/mux-surface.test.ts
@@ -32,6 +32,7 @@ import {
 	trackTempFile,
 	waitForFile,
 	waitForScreen,
+	shellQuote,
 	type TestEnv,
 } from "./harness.ts";
 import {
@@ -167,18 +168,20 @@ for (const backend of backends) {
 				branch,
 				baseSha,
 			);
+			const cwdFile = `/tmp/pi-integ-worktree-cwd-${id}.txt`;
+			trackTempFile(env, cwdFile);
 			try {
 				assert.equal(worktree.branch, branch);
 				assert.ok(worktree.path !== env.dir);
 				assert.equal(getFocusedSurface(backend), focusedPane);
 
 				await waitForPaneReady(worktree.paneId);
-				runInPane(worktree.paneId, "pwd");
-				await waitForScreen(
-					worktree.paneId,
-					new RegExp(worktree.path.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),
-					20_000,
-					50,
+				runInPane(worktree.paneId, `pwd > ${shellQuote(cwdFile)}`);
+				const capturedCwd = await waitForFile(cwdFile, 20_000);
+				assert.equal(
+					capturedCwd.trim(),
+					worktree.path,
+					"The launched worktree shell must start at the returned worktree path",
 				);
 
 				const listed = JSON.parse(

--- a/test/integration/subagent-lifecycle.test.ts
+++ b/test/integration/subagent-lifecycle.test.ts
@@ -1110,6 +1110,98 @@ for (const backend of backends) {
 				result.details.runtimePlan.model,
 				"pi-integration/fallback-secondary",
 			);
+			assert.equal(result.details.fallbackFailures.length, 1);
+			assert.equal(
+				result.details.fallbackFailures[0].model,
+				"pi-integration/fallback-primary",
+			);
+			assert.match(
+				result.details.fallbackFailures[0].error,
+				/deterministic fallback provider failure/,
+			);
+			assert.match(
+				result.content,
+				/Requested model: pi-integration\/fallback-primary/,
+			);
+			assert.match(
+				result.content,
+				/Model used: pi-integration\/fallback-secondary/,
+			);
+		});
+
+		it("advances after an account-style HTTP rejection without repeating that model", async () => {
+			const id = uniqueId();
+			const markerFile = `/tmp/pi-integ-account-fallback-${id}.txt`;
+			const parentSession = join(
+				env.dir,
+				`account-fallback-parent-${id}.jsonl`,
+			);
+			trackTempFile(env, markerFile);
+			const surface = createTrackedSurface(env, `account-fallback-${id}`);
+			await waitForPaneReady(surface);
+			startPi(
+				surface,
+				env.dir,
+				[
+					`Call subagent once with name: "AccountFallback-${id}".`,
+					'agent: "test-echo".',
+					`model: "pi-integration/account-rejected, pi-integration/fallback-secondary".`,
+					`task: "Run: echo 'ACCOUNT_FALLBACK_${id}' > '${markerFile}'".`,
+				].join("\n"),
+				{ extraArgs: `--session ${shellQuote(parentSession)}` },
+			);
+
+			assert.match(
+				await waitForFile(markerFile, PI_TIMEOUT),
+				new RegExp(`ACCOUNT_FALLBACK_${id}`),
+			);
+			await waitForFile(
+				parentSession,
+				PI_TIMEOUT,
+				/"customType":"subagent_result"/,
+			);
+			const entries = readFileSync(parentSession, "utf8")
+				.trim()
+				.split("\n")
+				.map((line) => JSON.parse(line));
+			const results = entries.filter(
+				(entry) =>
+					entry.type === "custom_message" &&
+					entry.customType === "subagent_result",
+			);
+			assert.equal(results.length, 1, "parent must receive one completion");
+			const result = results[0];
+			assert.deepEqual(result.details.fallbackAttempts, [
+				"pi-integration/account-rejected",
+				"pi-integration/fallback-secondary",
+			]);
+			assert.equal(
+				result.details.runtimePlan.model,
+				"pi-integration/fallback-secondary",
+			);
+			assert.equal(result.details.fallbackFailures.length, 1);
+			assert.equal(
+				result.details.fallbackFailures[0].model,
+				"pi-integration/account-rejected",
+			);
+			assert.match(
+				result.details.fallbackFailures[0].error,
+				/account-rejected.*not supported.*account/i,
+			);
+			assert.match(
+				result.content,
+				/Models attempted: pi-integration\/account-rejected, pi-integration\/fallback-secondary/,
+			);
+			assert.match(
+				result.content,
+				/Model used: pi-integration\/fallback-secondary/,
+			);
+			assert.doesNotMatch(result.content, /auto-retry exhausted/);
+			const rejectedRequests = getProviderRequests().filter(
+				(request) => request.model === "account-rejected",
+			);
+			assert.equal(rejectedRequests.length, 1);
+			assert.equal(rejectedRequests[0].status, 400);
 		});
 
 		it("reports every attempted model when all fallbacks fail", async () => {
@@ -1157,6 +1249,26 @@ for (const backend of backends) {
 				failedRequests.every((request) => request.status === 503),
 				true,
 			);
+			assert.equal(result.details.fallbackFailures.length, 2);
+			assert.deepEqual(
+				result.details.fallbackFailures.map(
+					(failure: { model: string }) => failure.model,
+				),
+				["pi-integration/fallback-primary", "pi-integration/fallback-fail"],
+			);
+			assert.match(
+				result.details.fallbackFailures[0].error,
+				/deterministic fallback provider failure/,
+			);
+			assert.match(
+				result.details.fallbackFailures[1].error,
+				/deterministic fallback provider failure/,
+			);
+			assert.match(
+				result.content,
+				/Models attempted: pi-integration\/fallback-primary, pi-integration\/fallback-fail/,
+			);
+			assert.doesNotMatch(result.content, /auto-retry exhausted/);
 		});
 	});
 }

--- a/test/integration/subagent-lifecycle.test.ts
+++ b/test/integration/subagent-lifecycle.test.ts
@@ -18,7 +18,13 @@
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+	writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import { getProviderRequests, resetProviderRequests } from "./fake-provider.ts";
 import {
@@ -555,13 +561,43 @@ for (const backend of backends) {
 		});
 
 		it("delivers completion after the parent starts a new session", async () => {
+			type SessionEntry = {
+				type?: string;
+				customType?: string;
+				details?: {
+					name?: string;
+					exitCode?: number;
+					resultContent?: string;
+				};
+				message?: { role?: string };
+			};
+
 			const id = uniqueId();
 			const startFile = `/tmp/pi-integ-switch-start-${id}.txt`;
 			const markerFile = `/tmp/pi-integ-switch-done-${id}.txt`;
 			const childDir = join(env.dir, "sibling-project");
+			const sessionDir = join(env.dir, `switch-sessions-${id}`);
+			const originalSession = join(sessionDir, "original.jsonl");
 			mkdirSync(childDir);
+			mkdirSync(sessionDir);
 			trackTempFile(env, startFile);
 			trackTempFile(env, markerFile);
+
+			const readSession = (path: string): SessionEntry[] => {
+				try {
+					return readFileSync(path, "utf8")
+						.trim()
+						.split("\n")
+						.filter(Boolean)
+						.map((line) => JSON.parse(line));
+				} catch {
+					return [];
+				}
+			};
+			const isMatchingReceipt = (entry: SessionEntry): boolean =>
+				entry.type === "custom_message" &&
+				entry.customType === "subagent_result" &&
+				entry.details?.name === `Switch-${id}`;
 
 			const surface = createTrackedSurface(env, `switch-${id}`);
 			await waitForPaneReady(surface);
@@ -575,8 +611,14 @@ for (const backend of backends) {
 				`Do not do anything else. Just call the subagent tool once.`,
 			].join("\n");
 
-			startPi(surface, env.dir, task);
+			startPi(surface, env.dir, task, {
+				extraArgs: [
+					`--session ${shellQuote(originalSession)}`,
+					`--session-dir ${shellQuote(sessionDir)}`,
+				].join(" "),
+			});
 			await waitForFile(startFile, PI_TIMEOUT, /START_/);
+			assert.equal(existsSync(originalSession), true);
 
 			runInPane(surface, "/new");
 
@@ -586,13 +628,54 @@ for (const backend of backends) {
 				"Subagent should finish after the parent session switch",
 			);
 
-			const screen = await waitForScreen(
-				surface,
-				new RegExp(`Switch-${id}.*completed|Sub-agent.*Switch-${id}`, "i"),
-				PI_TIMEOUT,
-				300,
+			let replacementSession: string | undefined;
+			const deadline = Date.now() + PI_TIMEOUT;
+			while (!replacementSession && Date.now() < deadline) {
+				for (const file of readdirSync(sessionDir).filter((name) =>
+					name.endsWith(".jsonl"),
+				)) {
+					const path = join(sessionDir, file);
+					if (path === originalSession) continue;
+					const entries = readSession(path);
+					const receiptIndex = entries.findIndex(isMatchingReceipt);
+					const settled =
+						receiptIndex >= 0 &&
+						entries
+							.slice(receiptIndex + 1)
+							.some(
+								(entry) =>
+									entry.type === "message" &&
+									entry.message?.role === "assistant",
+							);
+					if (entries.filter(isMatchingReceipt).length === 1 && settled) {
+						replacementSession = path;
+						break;
+					}
+				}
+				if (!replacementSession) await sleep(50);
+			}
+
+			const replacementPath = replacementSession;
+			assert.ok(
+				replacementPath,
+				`Expected a settled replacement session receipt. Parent screen:\n${readPane(surface, 300)}`,
 			);
-			assert.match(screen, new RegExp(`Switch-${id}`, "i"));
+			assert.notEqual(replacementPath, originalSession);
+			const replacementResults =
+				readSession(replacementPath).filter(isMatchingReceipt);
+			assert.equal(replacementResults.length, 1);
+			const receipt = replacementResults[0];
+			assert.equal(receipt.type, "custom_message");
+			assert.equal(receipt.customType, "subagent_result");
+			assert.ok(receipt.details, "Receipt must include structured details");
+			assert.equal(receipt.details?.name, `Switch-${id}`);
+			assert.equal(receipt.details?.exitCode, 0);
+			assert.match(receipt.details?.resultContent ?? "", /.+/);
+			assert.equal(
+				readSession(originalSession).filter(isMatchingReceipt).length,
+				0,
+				"Completion must not be delivered into the original parent session",
+			);
 		});
 
 		// ── In-progress activity snapshots ──

--- a/test/integration/subagent-lifecycle.test.ts
+++ b/test/integration/subagent-lifecycle.test.ts
@@ -804,7 +804,7 @@ for (const backend of backends) {
 			);
 		});
 
-		it("resumes a Pi session and delivers its new result to the parent", async () => {
+		it("rejects public resume of a legacy Pi session without a saved policy", async () => {
 			const id = uniqueId();
 			const sessionFile = join(env.dir, `resume-child-${id}.jsonl`);
 			const seedSurface = createTrackedSurface(env, `resume-seed-${id}`);
@@ -816,9 +816,18 @@ for (const backend of backends) {
 			assert.equal(await waitForPiExit(seedSurface), 0);
 			assert.equal(existsSync(sessionFile), true);
 
-			const resultMarker = `RESUME_RESULT_${id}`;
+			const parentSession = join(env.dir, `resume-parent-${id}.jsonl`);
 			const parentSurface = createTrackedSurface(env, `resume-parent-${id}`);
 			await waitForPaneReady(parentSurface);
+			const panesBefore = JSON.parse(
+				execFileSync(
+					"herdr",
+					["pane", "list", "--workspace", env.workspaceId],
+					{ encoding: "utf8" },
+				),
+			)
+				.result.panes.map((pane: { pane_id: string }) => pane.pane_id)
+				.sort();
 			startPi(
 				parentSurface,
 				env.dir,
@@ -828,16 +837,79 @@ for (const backend of backends) {
 					`  name: "Resume-${id}"`,
 					`  message: "RESUME_FOLLOWUP_INPUT: ${id}"`,
 					"  autoExit: true",
-					"Call the tool once and wait for its asynchronous result.",
+					"Call the tool once and report its result.",
 				].join("\n"),
+				{ extraArgs: `--session ${shellQuote(parentSession)}` },
 			);
 
-			const screen = await waitForScreen(
-				parentSurface,
-				new RegExp(resultMarker),
+			const transcript = await waitForFile(
+				parentSession,
 				PI_TIMEOUT,
+				/saved launch policy is missing/,
 			);
-			assert.match(screen, new RegExp(resultMarker));
+			assert.match(transcript, /Cannot safely resume/);
+			const panesAfter = JSON.parse(
+				execFileSync(
+					"herdr",
+					["pane", "list", "--workspace", env.workspaceId],
+					{ encoding: "utf8" },
+				),
+			)
+				.result.panes.map((pane: { pane_id: string }) => pane.pane_id)
+				.sort();
+			assert.deepEqual(panesAfter, panesBefore);
+		});
+
+		it("preserves restricted child tools and spawning denial across public resume", async () => {
+			const id = uniqueId();
+			const parentSession = join(
+				env.dir,
+				`resume-restricted-parent-${id}.jsonl`,
+			);
+			const surface = createTrackedSurface(env, `resume-restricted-${id}`);
+			await waitForPaneReady(surface);
+			startPi(surface, env.dir, `INTEGRATION_RESUME_RESTRICTIONS:${id}`, {
+				extraArgs: `--session ${shellQuote(parentSession)}`,
+			});
+
+			await waitForFile(
+				parentSession,
+				PI_TIMEOUT,
+				new RegExp(`RESUME_RESTRICTIONS_COMPLETE_${id}`),
+			);
+			const deadline = Date.now() + PI_TIMEOUT;
+			let results: Array<{ content: string }> = [];
+			while (Date.now() < deadline) {
+				const entries = readFileSync(parentSession, "utf8")
+					.trim()
+					.split("\n")
+					.map((line) => JSON.parse(line));
+				results = entries.filter(
+					(entry) =>
+						entry.type === "custom_message" &&
+						entry.customType === "subagent_result",
+				);
+				if (results.length === 2) break;
+				await sleep(50);
+			}
+			assert.equal(results.length, 2, "each child run delivers one result");
+			assert.match(results[1].content, new RegExp(`RESTRICTED_RESUME_${id}`));
+			assert.doesNotMatch(
+				JSON.stringify(results),
+				new RegExp(`RESTRICTED_TOOL_LEAK_${id}`),
+			);
+			const restrictedRequests = getProviderRequests().filter(
+				(request) =>
+					request.tools?.includes("caller_ping") &&
+					request.tools.includes("read"),
+			);
+			assert.ok(
+				restrictedRequests.length >= 2,
+				"fresh and resumed children both reached the deterministic provider",
+			);
+			for (const request of restrictedRequests) {
+				assert.deepEqual(request.tools, ["caller_ping", "read"]);
+			}
 		});
 
 		// ── Agent discovery ──

--- a/test/integration/workflow-review.test.ts
+++ b/test/integration/workflow-review.test.ts
@@ -27,6 +27,7 @@ import {
 	TEST_MODEL,
 } from "./harness.ts";
 import { isString } from "../../pi-extension/subagents/type-guards.ts";
+import { readSubagentSessionPolicy } from "../../pi-extension/subagents/session.ts";
 
 const backends = getAvailableBackends();
 
@@ -277,6 +278,14 @@ for (const backend of backends) {
 				);
 				assert.equal(starts.length, 4);
 				assert.equal(starts[3].role, "synthesizer");
+				assert.equal(
+					starts.every(
+						(event) =>
+							readSubagentSessionPolicy(event.sessionFile).owner === "workflow",
+					),
+					true,
+					"workflow child sessions are marked before public resume can create a pane",
+				);
 				assert.equal(
 					events.findIndex((event) => event.type === "agent_completed"),
 					6,

--- a/test/launch.test.ts
+++ b/test/launch.test.ts
@@ -19,6 +19,10 @@ import {
 	type ResumePiLaunchRequest,
 } from "../pi-extension/subagents/launch.ts";
 import { createSubagentPaneFactory } from "../pi-extension/subagents/pane-config.ts";
+import {
+	readSubagentSessionPolicy,
+	writeSubagentSessionPolicy,
+} from "../pi-extension/subagents/session.ts";
 
 function fixture() {
 	const root = mkdtempSync(join(tmpdir(), "subagent-launch-test-"));
@@ -77,6 +81,14 @@ function withFixture(
 	});
 }
 
+function writePublicResumePolicy(sessionFile: string): void {
+	writeSubagentSessionPolicy(sessionFile, {
+		owner: "public",
+		tools: "read,bash",
+		deniedTools: ["subagent", "subagent_resume"],
+	});
+}
+
 describe("Pi launch", () => {
 	it("launches an ordinary child through one transaction", async () => {
 		await withFixture(async ({ request, project, agentDir }) => {
@@ -119,6 +131,12 @@ describe("Pi launch", () => {
 			assert.equal(running.surface, "pane-1");
 			assert.equal(running.launchScriptFile, scriptPath);
 			assert.ok(running.sessionFile.startsWith(join(agentDir, "sessions")));
+			assert.deepEqual(readSubagentSessionPolicy(running.sessionFile), {
+				version: 1,
+				owner: "public",
+				tools: ["read", "bash"],
+				deniedTools: ["subagent", "subagent_resume"],
+			});
 			assert.equal(command.includes(projectAgentDir), false);
 			assert.match(command, new RegExp(`^cd '${project}' && `));
 			assert.match(command, /--model 'fake\/worker'/);
@@ -154,6 +172,7 @@ describe("Pi launch", () => {
 					const closed: string[] = [];
 					const sessionFile = join(root, "resumed.jsonl");
 					writeFileSync(sessionFile, "existing session\n");
+					if (kind === "resume") writePublicResumePolicy(sessionFile);
 					const launchRequest: FreshPiLaunchRequest | ResumePiLaunchRequest =
 						kind === "fresh"
 							? request
@@ -374,6 +393,7 @@ describe("Pi launch", () => {
 
 			const resumedSession = join(root, "resumed.jsonl");
 			writeFileSync(resumedSession, "existing session\n");
+			writePublicResumePolicy(resumedSession);
 			await launchPiSubagent(
 				{
 					kind: "resume",
@@ -474,6 +494,7 @@ describe("Pi launch", () => {
 		await withFixture(async ({ root, sessionDir }) => {
 			const sessionFile = join(root, "child.jsonl");
 			writeFileSync(sessionFile, "existing session\n");
+			writePublicResumePolicy(sessionFile);
 			const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
 			process.env.PI_CODING_AGENT_DIR = join(root, "isolated-agent");
 			try {
@@ -535,7 +556,12 @@ describe("Pi launch", () => {
 						`^PI_CODING_AGENT_DIR='${process.env.PI_CODING_AGENT_DIR}' `,
 					),
 				);
-				assert.match(command, new RegExp(`pi --session '${sessionFile}' -e `));
+				assert.match(
+					command,
+					new RegExp(
+						`pi --session '${sessionFile}' --tools 'read,bash,caller_ping' -e `,
+					),
+				);
 				assert.match(command, /PI_SUBAGENT_NAME='Resume worker'/);
 				assert.match(
 					command,
@@ -544,6 +570,7 @@ describe("Pi launch", () => {
 				assert.match(command, /PI_SUBAGENT_ID='resume-1'/);
 				assert.match(command, /PI_SUBAGENT_ACTIVITY_FILE='/);
 				assert.match(command, /PI_SUBAGENT_AUTO_EXIT=1/);
+				assert.match(command, /PI_DENY_TOOLS='subagent,subagent_resume'/);
 				assert.doesNotMatch(command, /--model|--thinking|^cd /);
 				const messagePath = command.match(/'@([^']+\.md)'/)?.[1];
 				assert.ok(messagePath, "expected artifact-backed follow-up message");
@@ -571,6 +598,7 @@ describe("Pi launch", () => {
 		await withFixture(async ({ root, sessionDir }) => {
 			const sessionFile = join(root, "interactive.jsonl");
 			writeFileSync(sessionFile, "existing session\n");
+			writePublicResumePolicy(sessionFile);
 			const previousAutoExit = process.env.PI_SUBAGENT_AUTO_EXIT;
 			process.env.PI_SUBAGENT_AUTO_EXIT = "1";
 			try {
@@ -690,6 +718,10 @@ describe("Pi launch", () => {
 			assert.equal(running.worktree?.baseSha, baseSha);
 			assert.equal(running.worktree?.path, worktreePath);
 			assert.equal(running.worktree?.sessionFile, running.sessionFile);
+			assert.equal(
+				readSubagentSessionPolicy(running.sessionFile).owner,
+				"managed-worktree",
+			);
 			assert.match(command, new RegExp(`^cd '${worktreePath}' && `));
 			const manifest = JSON.parse(readFileSync(manifestFile, "utf8"));
 			assert.equal(manifest.state, "running");

--- a/test/test.ts
+++ b/test/test.ts
@@ -39,6 +39,9 @@ import {
 	seedSubagentSessionFile,
 	createBtwSessionSnapshot,
 	createWorktreeSessionFork,
+	getSubagentSessionPolicyFile,
+	readSubagentSessionPolicy,
+	writeSubagentSessionPolicy,
 	type SessionEntry,
 } from "../pi-extension/subagents/session.ts";
 
@@ -103,6 +106,7 @@ import {
 	type SubagentLifecycle,
 } from "../pi-extension/subagents/lifecycle.ts";
 import type { PendingWorkflow } from "../pi-extension/subagents/workflow.ts";
+import { launchPiSubagent } from "../pi-extension/subagents/launch.ts";
 
 // Tool-registration behavior is environment-sensitive for child subagents.
 // Isolate the unit suite from inherited parent/child capability variables.
@@ -533,6 +537,61 @@ describe("session.ts", () => {
 		});
 	});
 
+	describe("subagent session policy", () => {
+		it("persists an explicit allowlist separately from unrestricted launches", () => {
+			const restricted = join(dir, "restricted-policy.jsonl");
+			const unrestricted = join(dir, "unrestricted-policy.jsonl");
+			writeSubagentSessionPolicy(restricted, {
+				owner: "public",
+				tools: "read, read, ",
+				deniedTools: ["subagent", "subagent"],
+			});
+			writeSubagentSessionPolicy(unrestricted, {
+				owner: "public",
+				deniedTools: [],
+			});
+
+			assert.deepEqual(readSubagentSessionPolicy(restricted), {
+				version: 1,
+				owner: "public",
+				tools: ["read"],
+				deniedTools: ["subagent"],
+			});
+			assert.equal(readSubagentSessionPolicy(unrestricted).tools, null);
+			assert.equal(existsSync(getSubagentSessionPolicyFile(restricted)), true);
+		});
+
+		it("fails closed for missing, malformed, and unsupported policies", () => {
+			const sessionFile = join(dir, "policy-errors.jsonl");
+			assert.throws(
+				() => readSubagentSessionPolicy(sessionFile),
+				/saved launch policy is missing/,
+			);
+
+			const policyFile = getSubagentSessionPolicyFile(sessionFile);
+			writeFileSync(policyFile, "not json", "utf8");
+			assert.throws(
+				() => readSubagentSessionPolicy(sessionFile),
+				/saved launch policy cannot be read/,
+			);
+
+			writeFileSync(
+				policyFile,
+				JSON.stringify({
+					version: 2,
+					owner: "public",
+					tools: null,
+					deniedTools: [],
+				}),
+				"utf8",
+			);
+			assert.throws(
+				() => readSubagentSessionPolicy(sessionFile),
+				/launch policy version is unsupported/,
+			);
+		});
+	});
+
 	describe("seedSubagentSessionFile", () => {
 		it("creates a lineage-only child session with parent linkage and no copied turns", () => {
 			const parentFile = createSessionFile(dir, [
@@ -899,6 +958,164 @@ describe("session.ts", () => {
 			const targetLines = readFileSync(targetFile, "utf8").trim().split("\n");
 			assert.equal(targetLines.length, 3);
 		});
+	});
+});
+
+describe("subagent resume launch policy", () => {
+	function runtimePlan() {
+		return {
+			provider: "test",
+			modelId: "model",
+			model: "test/model",
+			thinking: "low" as const,
+			modelSource: "request" as const,
+			thinkingSource: "request" as const,
+		};
+	}
+
+	function launchOperations(commands: string[], createPane = () => "pane") {
+		return {
+			createPane,
+			createWorktree() {
+				throw new Error("worktree creation is not expected");
+			},
+			async waitForShellReady() {},
+			runScript(_surface: string, command: string) {
+				commands.push(command);
+				return "/tmp/launch.sh";
+			},
+			closePane() {},
+		};
+	}
+
+	it("snapshots restricted tools and spawning denial for repeated public resumes", async () => {
+		const dir = createTestDir();
+		try {
+			const commands: string[] = [];
+			const parentSession = join(dir, "parent.jsonl");
+			writeFileSync(
+				parentSession,
+				`${JSON.stringify(SESSION_HEADER)}\n`,
+				"utf8",
+			);
+			const fresh = await launchPiSubagent(
+				{
+					kind: "fresh",
+					id: "fresh-id",
+					name: "Restricted",
+					task: "inspect",
+					parent: {
+						cwd: dir,
+						sessionFile: parentSession,
+						sessionId: "parent-id",
+						sessionDir: join(dir, "parent-sessions"),
+						agentDir: join(dir, "agent"),
+					},
+					runtimePlan: runtimePlan(),
+					behavior: {
+						tools: "read",
+						deniedTools: ["subagent", "subagent_resume"],
+						autoExit: true,
+						interactive: false,
+						sessionMode: "standalone",
+					},
+				},
+				launchOperations(commands),
+			);
+			assert.deepEqual(readSubagentSessionPolicy(fresh.sessionFile), {
+				version: 1,
+				owner: "public",
+				tools: ["read"],
+				deniedTools: ["subagent", "subagent_resume"],
+			});
+
+			await launchPiSubagent(
+				{
+					kind: "resume",
+					name: "Restricted",
+					sessionFile: fresh.sessionFile,
+					parent: {
+						sessionId: "parent-id",
+						sessionDir: join(dir, "parent-sessions"),
+					},
+					behavior: { autoExit: false },
+				},
+				launchOperations(commands),
+			);
+			await launchPiSubagent(
+				{
+					kind: "resume",
+					name: "Restricted again",
+					sessionFile: fresh.sessionFile,
+					parent: {
+						sessionId: "parent-id",
+						sessionDir: join(dir, "parent-sessions"),
+					},
+				},
+				launchOperations(commands),
+			);
+
+			assert.match(
+				commands[1],
+				/PI_DENY_TOOLS='subagent,subagent_resume'.*--tools 'read,caller_ping,subagent_done'/,
+			);
+			assert.match(
+				commands[2],
+				/PI_DENY_TOOLS='subagent,subagent_resume'.*--tools 'read,caller_ping'/,
+			);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("rejects absent, malformed, workflow, and worktree policies before pane creation", async () => {
+		const dir = createTestDir();
+		try {
+			const sessionFile = join(dir, "resume.jsonl");
+			let panes = 0;
+			const operations = launchOperations([], () => {
+				panes += 1;
+				return "unexpected-pane";
+			});
+			const resume = () =>
+				launchPiSubagent(
+					{
+						kind: "resume",
+						name: "Resume",
+						sessionFile,
+						parent: { sessionId: "parent-id", sessionDir: dir },
+					},
+					operations,
+				);
+
+			await assert.rejects(resume, /saved launch policy is missing/);
+			writeFileSync(getSubagentSessionPolicyFile(sessionFile), "{", "utf8");
+			await assert.rejects(resume, /saved launch policy cannot be read/);
+			for (const tools of [[], ["read,write"], [" read"]]) {
+				writeFileSync(
+					getSubagentSessionPolicyFile(sessionFile),
+					JSON.stringify({
+						version: 1,
+						owner: "public",
+						tools,
+						deniedTools: [],
+					}),
+					"utf8",
+				);
+				await assert.rejects(resume, /saved launch tool policy is malformed/);
+			}
+			for (const owner of ["workflow", "managed-worktree"] as const) {
+				writeSubagentSessionPolicy(sessionFile, {
+					owner,
+					tools: ["read"],
+					deniedTools: [],
+				});
+				await assert.rejects(resume, new RegExp(`Cannot resume ${owner}`));
+			}
+			assert.equal(panes, 0);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
 	});
 });
 

--- a/test/test.ts
+++ b/test/test.ts
@@ -4057,6 +4057,37 @@ describe("completion.ts", () => {
 		assert.deepEqual(result, { reason: "sentinel", exitCode: 17 });
 	});
 
+	it("prefers an error sidecar published during the terminal read", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "completion-sentinel-race-"));
+		const sessionFile = join(dir, "child.jsonl");
+		try {
+			const result = await waitForCompletion(new AbortController().signal, {
+				intervalMs: 1,
+				sessionFile,
+				readTerminalTail: async () => {
+					await Promise.resolve();
+					writeFileSync(
+						`${sessionFile}.exit`,
+						JSON.stringify({
+							type: "error",
+							errorMessage: "account/model rejected",
+							stopReason: "error",
+						}),
+					);
+					return "output\n__SUBAGENT_DONE_1__\n";
+				},
+			});
+			assert.deepEqual(result, {
+				reason: "error",
+				exitCode: 1,
+				errorMessage: "account/model rejected",
+			});
+			assert.equal(existsSync(`${sessionFile}.exit`), false);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
 	it("retries transient terminal read failures and reports ticks", async () => {
 		let reads = 0;
 		let ticks = 0;
@@ -5292,7 +5323,8 @@ describe("subagent interruption", () => {
 		);
 
 		assert.match(presentation, /Sub-agent "Worker" failed/);
-		assert.match(presentation, /provider\/agent error — auto-retry exhausted/);
+		assert.match(presentation, /provider\/agent error/);
+		assert.doesNotMatch(presentation, /auto-retry exhausted/);
 		assert.match(
 			presentation,
 			/Error: Anthropic 529 Overloaded after 3 retries/,
@@ -5300,6 +5332,134 @@ describe("subagent interruption", () => {
 		assert.match(presentation, /subagent_resume/);
 		assert.match(presentation, /Resume: pi --session/);
 		assert.doesNotMatch(presentation, /ignored when errorMessage is present/);
+	});
+
+	it("does not advance fallback for a valid negative task result", () => {
+		const testApi = subagentsModule.__test__;
+		assert.equal(
+			testApi.shouldAdvanceToFallback({ errorMessage: undefined }, 1),
+			false,
+		);
+		assert.equal(
+			testApi.shouldAdvanceToFallback({ errorMessage: "provider failed" }, 1),
+			true,
+		);
+		assert.equal(
+			testApi.shouldAdvanceToFallback({ errorMessage: "provider failed" }, 0),
+			false,
+		);
+	});
+
+	it("preserves raw account/model errors and model evidence without retry claims", () => {
+		const testApi = subagentsModule.__test__;
+		const modelRef = "openai-codex/gpt-5.4";
+		const presentation = testApi.resolveResultPresentation(
+			{
+				exitCode: 1,
+				elapsed: 5,
+				summary: "ignored",
+				sessionFile: "/tmp/subagent.jsonl",
+				errorMessage:
+					"Codex error: The 'gpt-5.4' model is not supported when using Codex with a ChatGPT account.",
+				fallbackAttempts: [modelRef],
+				runtimePlan: {
+					provider: "openai-codex",
+					modelId: "gpt-5.4",
+					model: modelRef,
+					thinking: "medium",
+					modelSource: "request",
+					thinkingSource: "request",
+				},
+			},
+			"Worker",
+		);
+
+		assert.match(presentation, /Requested model: openai-codex\/gpt-5\.4/);
+		assert.match(presentation, /Model used: openai-codex\/gpt-5\.4/);
+		assert.match(
+			presentation,
+			/Error: Codex error: The 'gpt-5\.4' model is not supported.*ChatGPT account/,
+		);
+		assert.match(presentation, /Next action: check the raw provider reason/);
+		assert.doesNotMatch(presentation, /auto-retry exhausted|permanent failure/);
+	});
+
+	it("reports ordered fallback causes, attempted models, and the model used on success", () => {
+		const testApi = subagentsModule.__test__;
+		const presentation = testApi.resolveResultPresentation(
+			{
+				exitCode: 0,
+				elapsed: 6,
+				summary: "Useful result",
+				fallbackAttempts: ["fake/primary", "fake/middle", "fake/secondary"],
+				fallbackFailures: [
+					{ model: "fake/primary", error: "provider rejected fake/primary" },
+					{ model: "fake/middle", error: "provider rejected fake/middle" },
+				],
+				runtimePlan: {
+					provider: "fake",
+					modelId: "secondary",
+					model: "fake/secondary",
+					thinking: "medium",
+					modelSource: "request",
+					thinkingSource: "request",
+				},
+			},
+			"Worker",
+		);
+
+		assert.match(presentation, /Requested model: fake\/primary/);
+		assert.match(
+			presentation,
+			/Models attempted: fake\/primary, fake\/middle, fake\/secondary/,
+		);
+		assert.match(presentation, /Model used: fake\/secondary/);
+		assert.match(
+			presentation,
+			/Model failures .*fake\/primary: provider rejected fake\/primary.*fake\/middle: provider rejected fake\/middle/s,
+		);
+		assert.doesNotMatch(presentation, /auto-retry exhausted/);
+	});
+
+	it("reports every rejected fallback candidate without inventing retry counts", () => {
+		const testApi = subagentsModule.__test__;
+		const presentation = testApi.resolveResultPresentation(
+			{
+				exitCode: 1,
+				elapsed: 7,
+				summary: "ignored",
+				errorMessage: "provider rejected fake/secondary",
+				fallbackAttempts: ["fake/primary", "fake/middle", "fake/secondary"],
+				fallbackFailures: [
+					{ model: "fake/primary", error: "provider rejected fake/primary" },
+					{ model: "fake/middle", error: "provider rejected fake/middle" },
+					{
+						model: "fake/secondary",
+						error: "provider rejected fake/secondary",
+					},
+				],
+				runtimePlan: {
+					provider: "fake",
+					modelId: "secondary",
+					model: "fake/secondary",
+					thinking: "medium",
+					modelSource: "request",
+					thinkingSource: "request",
+				},
+			},
+			"Worker",
+		);
+
+		assert.match(
+			presentation,
+			/Models attempted: fake\/primary, fake\/middle, fake\/secondary/,
+		);
+		assert.match(presentation, /Model used: fake\/secondary/);
+		assert.match(
+			presentation,
+			/Model failures .*fake\/primary: provider rejected fake\/primary.*fake\/middle: provider rejected fake\/middle.*fake\/secondary: provider rejected fake\/secondary/s,
+		);
+		assert.doesNotMatch(presentation, /auto-retry exhausted|after \d+ retries/);
 	});
 
 	it("leaves small completion presentations unchanged", () => {
@@ -5689,6 +5849,45 @@ describe("subagent status renderer", () => {
 
 		assert.match(rendered, /Session: \/tmp\/subagent\.jsonl/);
 		assert.match(rendered, /Resume:\s+pi --session \/tmp\/subagent\.jsonl/);
+	});
+
+	it("recognizes the neutral provider error header when rendering expanded results", () => {
+		const { api, registeredMessageRenderers } = createMockExtensionApi();
+		subagentsModule.default(api);
+		const rendererEntry = registeredMessageRenderers.find(
+			(entry) => entry.name === "subagent_result",
+		);
+		assert.ok(rendererEntry);
+
+		const rendered = rendererEntry
+			.renderer(
+				{
+					customType: "subagent_result",
+					content:
+						'Sub-agent "Worker" failed after 5s (provider/agent error).\n\n' +
+						"Error: account/model rejected\n\n" +
+						"Requested model: openai-codex/gpt-5.4\n" +
+						"Model used: openai-codex/gpt-5.4",
+					details: {
+						name: "Worker",
+						exitCode: 1,
+						errorMessage: "account/model rejected",
+						resultContent:
+							'Sub-agent "Worker" failed after 5s (provider/agent error).\n\n' +
+							"Error: account/model rejected\n\n" +
+							"Requested model: openai-codex/gpt-5.4\n" +
+							"Model used: openai-codex/gpt-5.4",
+					},
+				},
+				{ expanded: true },
+				createTheme(),
+			)
+			.render(120)
+			.join("\n");
+
+		assert.match(rendered, /account\/model rejected/);
+		assert.match(rendered, /Requested model: openai-codex\/gpt-5\.4/);
+		assert.doesNotMatch(rendered, /auto-retry exhausted/);
 	});
 
 	it("renders result details while keeping the custom message context small", () => {

--- a/test/test.ts
+++ b/test/test.ts
@@ -2687,6 +2687,305 @@ describe("subagent discovery", () => {
 		);
 	});
 
+	it("rejects malformed capability declarations without widening role tools", async () => {
+		await withIsolatedAgentEnv(async ({ projectDir, projectAgentsDir }) => {
+			const rolePackDir = join(projectDir, "invalid-capability-pack");
+			const rolesDir = join(rolePackDir, "roles");
+			mkdirSync(rolesDir, { recursive: true });
+			writeFileSync(
+				join(rolePackDir, "package.json"),
+				JSON.stringify({ name: "@acme/invalid-capability-pack" }),
+			);
+			writeAgentFile(
+				rolesDir,
+				"multiline-tools",
+				["description: Invalid multiline tools", "tools:", "  - read"].join(
+					"\n",
+				),
+			);
+			writeAgentFile(
+				projectAgentsDir,
+				"empty-tools",
+				["description: Invalid empty tools", "tools:"].join("\n"),
+			);
+			writeAgentFile(
+				projectAgentsDir,
+				"duplicate-tools",
+				[
+					"description: Invalid duplicate tools",
+					"tools: read",
+					"tools: grep",
+				].join("\n"),
+			);
+			writeAgentFile(
+				projectAgentsDir,
+				"invalid-deny-tools",
+				[
+					"description: Invalid multiline deny tools",
+					"deny-tools:",
+					"  - subagent",
+				].join("\n"),
+			);
+			writeAgentFile(
+				projectAgentsDir,
+				"invalid-spawning",
+				["description: Invalid spawning boolean", "spawning: maybe"].join("\n"),
+			);
+			for (const [name, frontmatter] of [
+				[
+					"quoted-deny-tools",
+					["description: Quoted deny tools", 'deny-tools: "subagent"'].join(
+						"\n",
+					),
+				],
+				[
+					"comment-deny-tools",
+					[
+						"description: Commented deny tools",
+						"deny-tools: subagent # prevent recursion",
+					].join("\n"),
+				],
+				[
+					"quoted-tools",
+					["description: Quoted tools", 'tools: "read"'].join("\n"),
+				],
+				[
+					"comment-tools",
+					["description: Commented tools", "tools: read # inspection"].join(
+						"\n",
+					),
+				],
+				[
+					"indented-tools",
+					["description: Indented tools", "  tools: read"].join("\n"),
+				],
+				[
+					"spaced-tools",
+					["description: Spaced tools", "tools : read"].join("\n"),
+				],
+				[
+					"quoted-key-tools",
+					["description: Quoted key tools", '"tools": read'].join("\n"),
+				],
+			] as const) {
+				writeAgentFile(projectAgentsDir, name, frontmatter);
+			}
+			writeAgentFile(
+				projectAgentsDir,
+				"scout",
+				["description: Invalid bundled override", "tools: []"].join("\n"),
+			);
+			writeAgentFile(
+				projectAgentsDir,
+				"valid-comma-tools",
+				["description: Valid comma tools", "tools: read, grep"].join("\n"),
+			);
+			writeAgentFile(
+				projectAgentsDir,
+				"valid-deny-tools",
+				["description: Valid deny tools", "deny-tools: subagent"].join("\n"),
+			);
+			writeAgentFile(
+				projectAgentsDir,
+				"omitted-tools",
+				"description: Intentionally unrestricted",
+			);
+
+			const { api, registeredTools } = createMockExtensionApi();
+			api.events.on(
+				"pi-herdr-subagents:roles:discover:v1",
+				(request: { register(path: string): void }) =>
+					request.register(rolesDir),
+			);
+			subagentsModule.default(api);
+
+			const listTool = registeredTools.find(
+				(tool) => tool.name === "subagents_list",
+			);
+			assert.ok(listTool, "expected subagents_list to be registered");
+			const result = await listTool.execute();
+			const names = new Set(
+				result.details.agents.map((agent: any) => agent.name),
+			);
+			for (const name of [
+				"multiline-tools",
+				"empty-tools",
+				"duplicate-tools",
+				"invalid-deny-tools",
+				"invalid-spawning",
+				"quoted-deny-tools",
+				"comment-deny-tools",
+				"quoted-tools",
+				"comment-tools",
+				"indented-tools",
+				"spaced-tools",
+				"quoted-key-tools",
+				"scout",
+			]) {
+				assert.equal(names.has(name), false, `${name} must be rejected`);
+			}
+			assert.equal(
+				result.details.agents.find(
+					(agent: any) => agent.name === "valid-comma-tools",
+				)?.tools,
+				"read, grep",
+			);
+			assert.equal(
+				result.details.agents.find(
+					(agent: any) => agent.name === "omitted-tools",
+				)?.tools,
+				undefined,
+			);
+			assert.equal(
+				testApi
+					.resolveDenyTools(testApi.loadAgentDefaults("valid-deny-tools"))
+					.has("subagent"),
+				true,
+				"a valid deny-tools scalar must resolve the actual tool name",
+			);
+			assert.equal(
+				result.details.diagnostics.filter(
+					(diagnostic: any) =>
+						diagnostic.code === "invalid-capability-declaration",
+				).length,
+				13,
+			);
+			assert.match(result.content[0].text, /tools must use a non-empty/i);
+			assert.match(result.content[0].text, /spawning must be true or false/i);
+			assert.match(
+				result.content[0].text,
+				/comments and quotes are unsupported/i,
+			);
+			assert.match(result.content[0].text, /unquoted, unindented key/i);
+
+			const subagentTool = registeredTools.find(
+				(tool) => tool.name === "subagent",
+			);
+			assert.ok(subagentTool, "expected subagent to be registered");
+			const previousHerdrEnv = process.env.HERDR_ENV;
+			delete process.env.HERDR_ENV;
+			try {
+				const launch = await subagentTool.execute(
+					"call-1",
+					{ name: "Malformed", task: "Review this branch", agent: "scout" },
+					new AbortController().signal,
+					() => {},
+					{},
+				);
+				assert.equal(launch.details.error, "invalid-capability-declaration");
+				assert.match(launch.content[0].text, /tools/i);
+			} finally {
+				restoreEnvVar("HERDR_ENV", previousHerdrEnv);
+			}
+		});
+	});
+
+	it("uses the effective higher-precedence role before launch diagnostics", async () => {
+		await withIsolatedAgentEnv(
+			async ({ projectDir, projectAgentsDir, globalAgentsDir }) => {
+				const rolePackDir = join(projectDir, "precedence-capability-pack");
+				const rolesDir = join(rolePackDir, "roles");
+				mkdirSync(rolesDir, { recursive: true });
+				writeFileSync(
+					join(rolePackDir, "package.json"),
+					JSON.stringify({ name: "@acme/precedence-capability-pack" }),
+				);
+				writeAgentFile(
+					globalAgentsDir,
+					"global-invalid-project-valid",
+					["description: Invalid global", "tools: []"].join("\n"),
+				);
+				writeAgentFile(
+					projectAgentsDir,
+					"global-invalid-project-valid",
+					["description: Valid project", "tools: read"].join("\n"),
+				);
+				writeAgentFile(
+					rolesDir,
+					"pack-invalid-project-valid",
+					["description: Invalid pack", "tools: []"].join("\n"),
+				);
+				writeAgentFile(
+					projectAgentsDir,
+					"pack-invalid-project-valid",
+					["description: Valid project", "tools: read"].join("\n"),
+				);
+				writeAgentFile(
+					globalAgentsDir,
+					"invalid-hidden-project-valid",
+					["description: Invalid global", "tools: []"].join("\n"),
+				);
+				writeAgentFile(
+					projectAgentsDir,
+					"invalid-hidden-project-valid",
+					[
+						"description: Valid hidden project",
+						"tools: read",
+						"disable-model-invocation: true",
+					].join("\n"),
+				);
+
+				const { api, registeredTools } = createMockExtensionApi();
+				api.events.on(
+					"pi-herdr-subagents:roles:discover:v1",
+					(request: { register(path: string): void }) =>
+						request.register(rolesDir),
+				);
+				subagentsModule.default(api);
+
+				const catalog = testApi.discoverAgentCatalog(api);
+				assert.equal(
+					catalog.diagnostics.filter(
+						(diagnostic) =>
+							diagnostic.code === "invalid-capability-declaration",
+					).length,
+					3,
+					"invalid lower-precedence roles remain visible as diagnostics",
+				);
+				for (const name of [
+					"global-invalid-project-valid",
+					"pack-invalid-project-valid",
+					"invalid-hidden-project-valid",
+				]) {
+					const agent = catalog.agents.find(
+						(candidate) => candidate.name === name,
+					);
+					assert.equal(agent?.source, "project");
+					assert.equal(agent?.tools, "read");
+				}
+
+				const subagentTool = registeredTools.find(
+					(tool) => tool.name === "subagent",
+				);
+				assert.ok(subagentTool, "expected subagent to be registered");
+				const previousHerdrEnv = process.env.HERDR_ENV;
+				delete process.env.HERDR_ENV;
+				try {
+					for (const agent of [
+						"global-invalid-project-valid",
+						"pack-invalid-project-valid",
+						"invalid-hidden-project-valid",
+					]) {
+						const launch = await subagentTool.execute(
+							"call-1",
+							{ name: "Valid override", task: "Inspect", agent },
+							new AbortController().signal,
+							() => {},
+							{},
+						);
+						assert.equal(launch.details.error, "herdr not available");
+						assert.doesNotMatch(
+							launch.content[0].text,
+							/invalid capability declaration/i,
+						);
+					}
+				} finally {
+					restoreEnvVar("HERDR_ENV", previousHerdrEnv);
+				}
+			},
+		);
+	});
+
 	it("rejects legacy external CLI roles before launch", async () => {
 		await withIsolatedAgentEnv(
 			async ({ globalAgentsDir, projectAgentsDir }) => {

--- a/test/workflow.test.ts
+++ b/test/workflow.test.ts
@@ -1399,6 +1399,72 @@ describe("workflow preparation", () => {
 		});
 	});
 
+	it("accounts for active agents before every non-cancel terminal outcome", async () => {
+		const baseSha = execFileSync("git", ["-C", root, "rev-parse", "HEAD"], {
+			encoding: "utf8",
+		}).trim();
+		const cases = [
+			{
+				name: "early return",
+				body: "agent('review', { kind: 'review', role: 'reviewer' });\nreturn { early: true };\n",
+				state: "completed",
+			},
+			{
+				name: "workflow exception",
+				body: "agent('review', { kind: 'review', role: 'reviewer' });\nthrow new Error('boom');\n",
+				state: "failed",
+			},
+			{
+				name: "deadline",
+				body: "return await agent('review', { kind: 'review', role: 'reviewer' });\n",
+				state: "failed",
+				deadlineMs: 100,
+			},
+			{
+				name: "Worker exit",
+				body: "agent('review', { kind: 'review', role: 'reviewer' });\nagent.constructor('return process')().exit(1);\n",
+				state: "failed",
+			},
+		] as const;
+		for (const testCase of cases) {
+			const candidate = prepare(
+				root,
+				writeWorkflow(
+					root,
+					workflow(baseSha) + testCase.body,
+					`terminal-${testCase.name.replace(" ", "-")}`,
+				),
+			);
+			let resolveAgent!: () => void;
+			let active = false;
+			let settled = false;
+			const terminalStates: string[] = [];
+			const result = await executeWorkflow(candidate, {
+				deadlineMs: "deadlineMs" in testCase ? testCase.deadlineMs : 1_000,
+				onAgent: () =>
+					new Promise((resolve) => {
+						active = true;
+						resolveAgent = () => {
+							settled = true;
+							resolve({ ok: true, value: "late" });
+						};
+					}),
+				onTerminal: async (outcome) => {
+					terminalStates.push(outcome.state);
+					assert.equal(
+						active,
+						true,
+						`${testCase.name} must see its active agent`,
+					);
+					resolveAgent();
+				},
+			});
+			assert.equal(result.state, testCase.state, testCase.name);
+			assert.deepEqual(terminalStates, [testCase.state], testCase.name);
+			assert.equal(settled, true, testCase.name);
+		}
+	});
+
 	it("preserves failed review evidence for synthesis and an incomplete task result", async () => {
 		const baseSha = execFileSync("git", ["-C", root, "rev-parse", "HEAD"], {
 			encoding: "utf8",


### PR DESCRIPTION
## Summary

Deliver the reliability milestone in five separate signed commits:

| Issue | Commit | Change |
| --- | --- | --- |
| #25 | e928817 | Account for active workflow children before terminal delivery and checkout disposal; retain evidence when exit cannot be confirmed. |
| #26 | 9b46c5c | Persist effective tool/deny policy and restore it on resume; reject missing, malformed, workflow-owned, and managed-worktree policies before creating a pane. |
| #27 | 0d263b8 | Reject malformed capability declarations, including quoted/commented values and noncanonical keys, while preserving valid higher-priority role overrides. |
| #28 | ec277ff | Replace wrapping-sensitive screen assertions with actual shell-cwd evidence and structured, exactly-once delivery checks in the replacement parent session. |
| #24 (extension-owned scope) | a6366ee | Report requested, attempted, and used models with ordered failure causes; remove unsupported retry claims; preserve authoritative error metadata when terminal output races the completion sidecar. |

Closes #25.
Closes #26.
Closes #27.
Closes #28.

Related: #24. Its upstream-dependent requirements remain open: Pi does not expose reliable account-error classification or retry counts through the extension API. This change documents that boundary rather than adding a model blacklist, free-text permanence classifier, or invented retry metadata.

## Compatibility and safety

- Legacy sessions without a saved launch-policy sidecar now fail public resume with explicit recovery guidance instead of silently gaining capabilities.
- Public resume cannot select a different model. Changing models requires a new launch; managed-worktree and workflow sessions retain their separate recovery paths.
- Existing configured model fallback behavior is preserved. A valid negative task result does not trigger a model switch.
- Exact workflow approval and worktree fallback restrictions remain unchanged.
- No package version bump, automatic integration, publication, or cleanup of retained user worktrees.

## Verification

Verified source: `a6366eea08ec6679535f3f4fa9dbd6c9201254e9`.

- `npm test`: **306 passed**, 0 failed, 0 skipped.
- `npm run test:integration`: **32 passed**, 0 failed, 0 skipped, using real Herdr/Pi processes with the deterministic provider and the working-tree extension.
- Focused fallback integration tests: **3 passed**.
- `npm run format:check`: passed.
- `npm run lint`: passed.
- `npm pack --dry-run`: passed; required package files included and generated/local artifacts excluded.
- `git diff --check`: passed.
- Independent review completed for each issue slice and subsequent corrections; final commit trees match the reviewed and tested snapshots.

The final full integration run follows a deterministic regression and repair for the sidecar/terminal-read race that an earlier replay exposed. Existing inferred-project TypeScript diagnostics outside the changed behavior remain out of scope. The optional live-provider smoke suite was not run.
