### PR TITLE
feat: event-driven supervision with file wake-ups and batched reconciliation (#29)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ Bundled role prompts live in [`agents/`](agents/). The native `/skill:orchestrat
 - `pi-extension/subagents/herdr.ts` — Herdr CLI argument construction and response parsing
 - `pi-extension/subagents/terminal.ts` — terminal adapter used by the lifecycle
 - `pi-extension/subagents/lifecycle.ts`, `status.ts`, `activity.ts` — process/turn state and widget projection
+- `pi-extension/subagents/wake.ts`, `supervision.ts`, `supervision-config.ts` — file wake-ups, shared pane reconciliation, polling fallback, and supervision configuration
 - `pi-extension/subagents/persistent-config.ts` — strict persistent-specialist cap configuration
 - `pi-extension/subagents/completion.ts`, `session.ts`, `subagent-done.ts` — child completion, transcript handling, `caller_ping`, and `subagent_done`
 - `CONTEXT.md` — orchestration-domain glossary
@@ -33,6 +34,7 @@ Bundled role prompts live in [`agents/`](agents/). The native `/skill:orchestrat
 - `test/test.ts` — unit tests for public subagent extension seams
 - `test/package-skill.test.js` — bundled skill and package manifest contract test
 - `test/integration/` — real Herdr and Pi lifecycle tests using the deterministic provider by default
+- `test/bench/supervision-bench.mjs` — manual isolated-Herdr supervision transport benchmark; raw samples stay in `/tmp/issue29-bench/`
 
 ## Worktree contract
 

--- a/README.md
+++ b/README.md
@@ -300,6 +300,9 @@ cp config.json.example config.json
   "persistent": {
     "maxAgents": 3
   },
+  "supervision": {
+    "forcePolling": false
+  },
   "panes": {
     "mode": "tab",
     "direction": "right"
@@ -340,9 +343,12 @@ pane inspection becomes unavailable, supervision quietly returns to the legacy
 one-second polling cadence. No caller action is required.
 
 Set `supervision.forcePolling` to `true` in the package-local `config.json` to
-disable wake-ups and use that legacy cadence deliberately. `subagents_list`
-reports the active transport mode (`wake+batch`, `polling(forced)`, or
-`polling(fallback)`) and watcher count.
+disable wake-ups and use that legacy cadence deliberately. The setting is read
+when the coordinator is created, so run `/reload` after changing it.
+`subagents_list` reports the active transport mode (`wake+batch`,
+`polling(forced)`, or `polling(fallback)`) and watcher count.
+`polling(fallback)` means at least one tracked child is using per-child polling;
+other children can still use wake+batch.
 
 A Linux manual benchmark on 2026-09-06 used isolated Herdr panes held pending,
 20-second windows, and the extension's completion/supervision seams. At 10

--- a/README.md
+++ b/README.md
@@ -331,6 +331,28 @@ Set `persistent.maxAgents` to the maximum concurrently retained persistent speci
 
 Set `roles.bundled` to `false` to exclude this package's bundled role definitions from listing and exact-name launch. It defaults to `true`. Registered role packs remain available, and global and project definitions keep their existing precedence. A role-pack name collides with a bundled role only while that bundled layer is enabled; when it is disabled, the role pack can supply that name.
 
+### Supervision transport
+
+On supported local filesystems, supervision uses file wake-ups plus one shared
+4.8-second pane reconciliation. A wake-up only prompts fresh evidence
+collection; it never establishes a result by itself. If the watcher or shared
+pane inspection becomes unavailable, supervision quietly returns to the legacy
+one-second polling cadence. No caller action is required.
+
+Set `supervision.forcePolling` to `true` in the package-local `config.json` to
+disable wake-ups and use that legacy cadence deliberately. `subagents_list`
+reports the active transport mode (`wake+batch`, `polling(forced)`, or
+`polling(fallback)`) and watcher count.
+
+A Linux manual benchmark on 2026-09-06 used isolated Herdr panes held pending,
+20-second windows, and the extension's completion/supervision seams. At 10
+children across three rotated rounds, wake+batch averaged 2.20 CLI launches/s
+versus 14.20 for forced polling (84.5% fewer); mean evidence-to-resolver
+latency was 3.2 ms versus 449.0 ms, and the largest reconciliation probe gap
+was 4.82 s. The benchmark measures `/proc` CPU ticks for the supervisor and
+isolated Herdr tree, not parent-model latency; raw samples are written to
+`/tmp/issue29-bench/` by `test/bench/supervision-bench.mjs`.
+
 Set `panes.mode` to `"split"` to open ordinary public `subagent` and `subagent_resume` launches, including bare forks and `/iterate`, as splits of the stable parent pane. Set `panes.direction` to `"right"` or `"down"`; it defaults to `"right"` and is ignored when mode is `"tab"`. The default `"tab"` mode preserves existing behavior. Managed worktrees still use separate workspaces, while `/btw` keeps its existing tab behavior.
 
 Run `/reload` after changing role, model, or pane settings.

--- a/config.json.example
+++ b/config.json.example
@@ -11,6 +11,9 @@
   "persistent": {
     "maxAgents": 3
   },
+  "supervision": {
+    "forcePolling": false
+  },
   "panes": {
     "mode": "tab",
     "direction": "right"

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,10 @@ launches fresh public reviewers, receives automatic completion delivery, and
 has the parent synthesize outcomes. Role frontmatter tool allowlists are the
 available enforcement boundary; `read,bash` is not read-only. Automated package
 acceptance covers unit tests, lint, and `npm pack --dry-run`. Deterministic
-Herdr integration is a manual release gate run from inside Herdr.
+Herdr integration is a manual release gate run from inside Herdr. The manual
+supervision transport benchmark is `../test/bench/supervision-bench.mjs`; it
+uses an isolated Herdr server and writes uncommitted raw samples to
+`/tmp/issue29-bench/`.
 
 ## ADRs
 

--- a/pi-extension/subagents/completion.ts
+++ b/pi-extension/subagents/completion.ts
@@ -24,6 +24,10 @@ export interface CompletionOptions {
 	) => void;
 	sessionFile?: string;
 	onTick?: (elapsedSeconds: number) => void;
+	/** Wait for a local file wake-up or a scheduled reconciliation. */
+	waitForNextCheck?: (signal: AbortSignal) => Promise<"wake" | "reconcile">;
+	/** Drain local task evidence before any terminal fallback. */
+	onLocalEvidence?: () => void;
 }
 
 export function interpretExitSidecar(payload: any): CompletionResult {
@@ -129,35 +133,41 @@ export async function waitForCompletion(
 ): Promise<CompletionResult> {
 	const startedAt = Date.now();
 
+	// Coordinated supervision waits for its first shared epoch; legacy callers
+	// retain the immediate terminal probe.
+	let reconcile = !options.waitForNextCheck;
 	for (;;) {
 		if (signal.aborted) throw new Error(ABORT_MESSAGE);
 
 		const sidecarResult = consumeExitSidecar(options.sessionFile);
 		if (sidecarResult) return sidecarResult;
+		options.onLocalEvidence?.();
 
-		try {
-			const exitCode = terminalExitCode(await options.readTerminalTail());
-			if (exitCode !== null) {
-				// The shell sentinel can become readable while the child publishes its
-				// authoritative semantic record. Always recheck after the asynchronous
-				// terminal read; a zero exit can race a ping or error just like a failure.
-				const racedCompletion = completionArtifact(options);
-				if (racedCompletion) return racedCompletion;
-				if (exitCode !== 0) {
-					const delayedCompletion = await waitForDelayedSidecar(
-						signal,
-						options,
-					);
-					if (delayedCompletion) return delayedCompletion;
+		if (reconcile)
+			try {
+				const exitCode = terminalExitCode(await options.readTerminalTail());
+				if (exitCode !== null) {
+					// The shell sentinel can become readable while the child publishes its
+					// authoritative semantic record. Always recheck after the asynchronous
+					// terminal read; a zero exit can race a ping or error just like a failure.
+					options.onLocalEvidence?.();
+					const racedCompletion = completionArtifact(options);
+					if (racedCompletion) return racedCompletion;
+					if (exitCode !== 0) {
+						const delayedCompletion = await waitForDelayedSidecar(
+							signal,
+							options,
+						);
+						if (delayedCompletion) return delayedCompletion;
+					}
+					return { reason: "sentinel", exitCode };
 				}
-				return { reason: "sentinel", exitCode };
+			} catch {
+				// Terminal reads are only sentinel/output probes; Herdr status is polled
+				// independently below, even when terminal reads succeed.
 			}
-		} catch {
-			// Terminal reads are only sentinel/output probes; Herdr status is polled
-			// independently below, even when terminal reads succeed.
-		}
 
-		if (options.inspectPane) {
+		if (reconcile && options.inspectPane) {
 			let inspection: import("./lifecycle.ts").PaneInspection;
 			try {
 				inspection = await options.inspectPane();
@@ -167,6 +177,8 @@ export async function waitForCompletion(
 			const observedAt = Date.now();
 			options.onPaneInspection?.(inspection, observedAt);
 			if (inspection.kind === "missing") {
+				// Drain concurrent persistent events before accepting pane fallback.
+				options.onLocalEvidence?.();
 				// Pane closure and atomic artifact publication are separate operations.
 				// Allow a short bounded grace window before declaring evidence lost.
 				const racedCompletion = await waitForDelayedSidecar(signal, options);
@@ -181,6 +193,11 @@ export async function waitForCompletion(
 		}
 
 		options.onTick?.(Math.floor((Date.now() - startedAt) / 1000));
-		await abortableDelay(options.intervalMs, signal);
+		if (options.waitForNextCheck) {
+			reconcile = (await options.waitForNextCheck(signal)) === "reconcile";
+		} else {
+			await abortableDelay(options.intervalMs, signal);
+			reconcile = true;
+		}
 	}
 }

--- a/pi-extension/subagents/completion.ts
+++ b/pi-extension/subagents/completion.ts
@@ -138,11 +138,17 @@ export async function waitForCompletion(
 		try {
 			const exitCode = terminalExitCode(await options.readTerminalTail());
 			if (exitCode !== null) {
-				// The shell sentinel can become readable just before the child writes
-				// its authoritative error sidecar. Preserve that error metadata.
+				// The shell sentinel can become readable while the child publishes its
+				// authoritative semantic record. Always recheck after the asynchronous
+				// terminal read; a zero exit can race a ping or error just like a failure.
+				const racedCompletion = completionArtifact(options);
+				if (racedCompletion) return racedCompletion;
 				if (exitCode !== 0) {
-					const racedCompletion = await waitForDelayedSidecar(signal, options);
-					if (racedCompletion) return racedCompletion;
+					const delayedCompletion = await waitForDelayedSidecar(
+						signal,
+						options,
+					);
+					if (delayedCompletion) return delayedCompletion;
 				}
 				return { reason: "sentinel", exitCode };
 			}

--- a/pi-extension/subagents/herdr.ts
+++ b/pi-extension/subagents/herdr.ts
@@ -474,6 +474,44 @@ function parsePaneGetError(error: any): PaneInspectionResult {
  * - missing: server responded, pane is gone
  * - unavailable: server command failed; caller should keep polling
  */
+export interface HerdrPaneListEntry {
+	paneId: string;
+	workspaceId: string;
+}
+
+/** Parse only complete snapshots; partial lists never establish pane absence. */
+export function parseHerdrPaneSnapshot(
+	output: string,
+): HerdrPaneListEntry[] | null {
+	const parsed = parseHerdrJson(output);
+	const panes = parsed?.result?.panes;
+	if (parsed?.result?.type !== "pane_list" || !Array.isArray(panes))
+		return null;
+	const ids = new Set<string>();
+	const result: HerdrPaneListEntry[] = [];
+	for (const pane of panes) {
+		if (
+			!isString(pane?.pane_id) ||
+			!pane.pane_id ||
+			!isString(pane?.workspace_id) ||
+			!pane.workspace_id ||
+			ids.has(pane.pane_id)
+		)
+			return null;
+		ids.add(pane.pane_id);
+		result.push({ paneId: pane.pane_id, workspaceId: pane.workspace_id });
+	}
+	return result;
+}
+
+export async function listHerdrPanes(): Promise<HerdrPaneListEntry[] | null> {
+	try {
+		return parseHerdrPaneSnapshot(await herdrExecAsync(["pane", "list"]));
+	} catch {
+		return null;
+	}
+}
+
 export async function inspectHerdrPane(
 	surface: string,
 ): Promise<PaneInspectionResult> {
@@ -751,6 +789,7 @@ export const __herdrTest__ = {
 	parseHerdrPaneList,
 	parsePaneGetOutput,
 	parsePaneGetError,
+	parseHerdrPaneSnapshot,
 	parsePaneProcessInfo,
 	isHerdrShellReady,
 	isExpectedPiProcess,

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -33,9 +33,15 @@ import {
 	shellQuote,
 	readPaneAsync,
 	inspectPane,
+	listPanes,
 	waitForShellReady,
 } from "./terminal.ts";
 import { waitForCompletion } from "./completion.ts";
+import {
+	SupervisionCoordinator,
+	type SupervisionRegistration,
+} from "./supervision.ts";
+import { loadSupervisionConfig } from "./supervision-config.ts";
 import {
 	buildAuthenticatedModelCatalog,
 	resolveRuntimePlan,
@@ -853,6 +859,16 @@ function formatLivePersistentSpecialists(): string[] {
 	];
 }
 
+function formatSupervisionDiagnostics(): string[] {
+	const diagnostics = runtime.supervision?.diagnostics() ?? {
+		mode: supervisionConfig.forcePolling ? "polling(forced)" : "wake+batch",
+		watcherCount: 0,
+	};
+	return [
+		`Supervision: ${diagnostics.mode}; ${diagnostics.watcherCount} watcher${diagnostics.watcherCount === 1 ? "" : "s"}`,
+	];
+}
+
 function formatAgentDiagnostics(diagnostics: AgentDiagnostic[]): string[] {
 	return diagnostics.map((diagnostic) => `! ${diagnostic.message}`);
 }
@@ -1044,6 +1060,7 @@ const statusConfig = loadStatusConfig();
 const modelConfig = loadModelConfig();
 const bundledRoleConfig = loadRoleConfig();
 const persistentConfig = loadPersistentConfig();
+const supervisionConfig = loadSupervisionConfig();
 
 const MAX_RESULT_PRESENTATION_CHARS = 16_000;
 const MAX_SESSION_REFERENCE_CHARS = 10_000;
@@ -1356,10 +1373,12 @@ interface RunningSubagent {
 	stopTimeout?: ReturnType<typeof setTimeout>;
 	stopTimeoutMs?: number;
 	crashNotified?: boolean;
+	supervisionRegistration?: SupervisionRegistration;
 }
 
 interface SubagentRuntime {
 	runningSubagents: Map<string, RunningSubagent>;
+	supervision?: SupervisionCoordinator;
 	pi?: ExtensionAPI;
 	latestCtx?: ExtensionContext;
 	modelCatalog?: string;
@@ -2587,17 +2606,37 @@ function notifyPersistentCrash(
 	);
 }
 
-function watchPersistentTaskEvents(
-	running: RunningSubagent,
-	api: Pick<ExtensionAPI, "sendMessage">,
-): ReturnType<typeof setInterval> {
-	return setInterval(() => {
-		try {
-			drainPersistentTaskEvents(running, api);
-		} catch {
-			// Leave the event unread so the next poll can retry delivery.
-		}
-	}, 1000);
+function getSupervisionCoordinator(): SupervisionCoordinator {
+	if (runtime.supervision) return runtime.supervision;
+	runtime.supervision = new SupervisionCoordinator(
+		async () => {
+			const panes = await listPanes();
+			if (!panes) return { complete: false, panes: [] };
+			return {
+				complete: true,
+				panes: panes.map((pane) => ({
+					...pane,
+					// SAFETY: this literal is the present PaneInspection variant.
+					inspection: {
+						kind: "present",
+						observedAt: Date.now(),
+					} as PaneInspection,
+				})),
+			};
+		},
+		inspectPane,
+		supervisionConfig.forcePolling,
+	);
+	return runtime.supervision;
+}
+
+function drainPersistentEventsSafely(running: RunningSubagent): void {
+	if (!running.persistent || !runtime.pi) return;
+	try {
+		drainPersistentTaskEvents(running, runtime.pi);
+	} catch {
+		// Leave an unread task event for the next file wake-up or reconciliation.
+	}
 }
 
 async function watchSubagent(
@@ -2605,13 +2644,20 @@ async function watchSubagent(
 	signal: AbortSignal,
 ): Promise<SubagentResult> {
 	const { name, task, surface, startTime, sessionFile } = running;
+	const supervision = getSupervisionCoordinator().register(
+		sessionFile,
+		surface,
+	);
+	running.supervisionRegistration = supervision;
 
 	try {
 		const result = await waitForCompletion(signal, {
 			intervalMs: 1000,
 			sessionFile,
+			waitForNextCheck: supervision.wait,
 			readTerminalTail: () => readPaneAsync(surface, 5),
-			inspectPane: async () => inspectPane(surface),
+			inspectPane: supervision.inspectPane,
+			onLocalEvidence: () => drainPersistentEventsSafely(running),
 			onPaneInspection: (inspection: PaneInspection, observedAt: number) => {
 				ensureLifecycle(running);
 				running.lifecycle = observePaneInspection(
@@ -2741,6 +2787,11 @@ async function watchSubagent(
 		};
 		if (worktreeHandoff) errorResult.worktree = worktreeHandoff;
 		return errorResult;
+	} finally {
+		supervision.unregister();
+		if (running.supervisionRegistration === supervision) {
+			running.supervisionRegistration = undefined;
+		}
 	}
 }
 
@@ -2909,6 +2960,10 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 		}
 
 		cleanupSubagentsForShutdown(event.reason, runningSubagents);
+		if (!shouldPreserveSubagentsOnShutdown(event.reason)) {
+			runtime.supervision?.close();
+			runtime.supervision = undefined;
+		}
 		try {
 			await closeBtw();
 		} catch {
@@ -3066,15 +3121,6 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 				startWidgetRefresh();
 				startStatusRefresh(pi);
 
-				// Persistent specialists deliver task events while the normal watcher remains
-				// responsible for a real process exit or pane disappearance.
-				const persistentTaskPoller = running.persistent
-					? watchPersistentTaskEvents(
-							running,
-							selectCompletionApi(pi, runtime.pi),
-						)
-					: undefined;
-
 				// Fire-and-forget: start watching in background
 				watchSubagentWithFallbacks(
 					running,
@@ -3092,7 +3138,6 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 								completedRunning,
 								selectCompletionApi(pi, runtime.pi),
 							);
-						if (persistentTaskPoller) clearInterval(persistentTaskPoller);
 						if (completedRunning.stopTimeout)
 							clearTimeout(completedRunning.stopTimeout);
 						if (completedRunning.persistent) {
@@ -3199,7 +3244,6 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 						sendSubagentResult(completionApi, presentation, resultDetails);
 					})
 					.catch((err) => {
-						if (persistentTaskPoller) clearInterval(persistentTaskPoller);
 						if (!shouldDeliverSubagentCompletion(running)) {
 							running.lifecycle = markDelivery(running.lifecycle, "suppressed");
 							runningSubagents.delete(running.id);
@@ -3483,6 +3527,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 				const lines = [
 					...formatVisibleAgentDefinitions(list),
 					...formatLivePersistentSpecialists(),
+					...formatSupervisionDiagnostics(),
 					...formatAgentDiagnostics(catalog.diagnostics),
 				];
 

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -2612,17 +2612,7 @@ function getSupervisionCoordinator(): SupervisionCoordinator {
 		async () => {
 			const panes = await listPanes();
 			if (!panes) return { complete: false, panes: [] };
-			return {
-				complete: true,
-				panes: panes.map((pane) => ({
-					...pane,
-					// SAFETY: this literal is the present PaneInspection variant.
-					inspection: {
-						kind: "present",
-						observedAt: Date.now(),
-					} as PaneInspection,
-				})),
-			};
+			return { complete: true, panes };
 		},
 		inspectPane,
 		supervisionConfig.forcePolling,

--- a/pi-extension/subagents/lifecycle.ts
+++ b/pi-extension/subagents/lifecycle.ts
@@ -403,7 +403,9 @@ export function observeActivity(
 			};
 		} else if (
 			lifecycle.pane.kind === "unknown" ||
-			lifecycle.pane.kind === "read-error"
+			lifecycle.pane.kind === "read-error" ||
+			(lifecycle.pane.kind === "present" &&
+				lifecycle.pane.agentStatus === "unknown")
 		) {
 			turn = {
 				kind: "active",

--- a/pi-extension/subagents/supervision-config.ts
+++ b/pi-extension/subagents/supervision-config.ts
@@ -1,0 +1,81 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { isBoolean, isRecord } from "./type-guards.ts";
+
+const PACKAGE_ROOT = join(dirname(fileURLToPath(import.meta.url)), "../..");
+const DEFAULT_CONFIG_PATH = join(PACKAGE_ROOT, "config.json");
+const EXAMPLE_CONFIG_PATH = join(PACKAGE_ROOT, "config.json.example");
+
+export interface SupervisionConfig {
+	forcePolling: boolean;
+}
+
+function invalid(source: string, message: string): never {
+	throw new Error(
+		`Invalid subagent supervision config in ${source}: ${message}`,
+	);
+}
+
+export function parseSupervisionConfig(
+	rawConfig: any,
+	source = "config.json",
+): SupervisionConfig {
+	if (!isRecord(rawConfig)) invalid(source, "root must be an object");
+	if (!Object.hasOwn(rawConfig, "supervision")) return { forcePolling: false };
+	if (!isRecord(rawConfig.supervision)) {
+		invalid(source, "supervision must be an object");
+	}
+	const unsupported = Object.keys(rawConfig.supervision).filter(
+		(key) => key !== "forcePolling",
+	);
+	if (unsupported.length > 0) {
+		invalid(
+			source,
+			`supervision has unsupported key(s): ${unsupported.join(", ")}`,
+		);
+	}
+	if (!Object.hasOwn(rawConfig.supervision, "forcePolling")) {
+		return { forcePolling: false };
+	}
+	if (!isBoolean(rawConfig.supervision.forcePolling)) {
+		invalid(source, "supervision.forcePolling must be a boolean");
+	}
+	return { forcePolling: rawConfig.supervision.forcePolling };
+}
+
+export function loadSupervisionConfig(
+	configPath = DEFAULT_CONFIG_PATH,
+	examplePath = EXAMPLE_CONFIG_PATH,
+): SupervisionConfig {
+	let sourcePath = configPath;
+	let rawConfig: string;
+	try {
+		rawConfig = readFileSync(configPath, "utf8");
+	} catch (error) {
+		// SAFETY: readFileSync only throws Node fs errors here, which carry code.
+		if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+		sourcePath = examplePath;
+		try {
+			rawConfig = readFileSync(examplePath, "utf8");
+		} catch (exampleError) {
+			// SAFETY: readFileSync only throws Node fs errors here, which carry code.
+			if ((exampleError as NodeJS.ErrnoException).code === "ENOENT") {
+				throw new Error(
+					`Missing subagent supervision config. Expected ${configPath} or ${examplePath}.`,
+				);
+			}
+			throw exampleError;
+		}
+	}
+	try {
+		return parseSupervisionConfig(JSON.parse(rawConfig), sourcePath);
+	} catch (error) {
+		if (error instanceof SyntaxError) {
+			throw new Error(
+				`Invalid JSON in subagent config ${sourcePath}: ${error.message}`,
+			);
+		}
+		throw error;
+	}
+}

--- a/pi-extension/subagents/supervision.ts
+++ b/pi-extension/subagents/supervision.ts
@@ -197,7 +197,10 @@ export class SupervisionCoordinator {
 		if (this.closed) return;
 		if (reason === "wake") entry.inspection = undefined;
 		if (entry.resolve) entry.resolve(reason);
-		else entry.pending = reason;
+		// A wake must never downgrade a queued reconciliation: the reconcile
+		// reason carries the epoch's pane inspection, and skipping it would
+		// defer pane-disappearance detection past the documented 5s bound.
+		else if (entry.pending !== "reconcile") entry.pending = reason;
 	}
 
 	private async reconcile(): Promise<void> {

--- a/pi-extension/subagents/supervision.ts
+++ b/pi-extension/subagents/supervision.ts
@@ -41,6 +41,14 @@ export interface SupervisionDiagnostics {
 	watcherCount: number;
 }
 
+interface SupervisionTimers {
+	setTimeout(
+		callback: () => void,
+		milliseconds: number,
+	): ReturnType<typeof setTimeout>;
+	clearTimeout(timer: ReturnType<typeof setTimeout>): void;
+}
+
 /** A runtime-owned coordinator for file wake-ups and shared pane snapshots. */
 export class SupervisionCoordinator {
 	private readonly entries = new Set<Entry>();
@@ -49,20 +57,27 @@ export class SupervisionCoordinator {
 		surface: string,
 	) => Promise<PaneInspection>;
 	private readonly forcePolling: boolean;
-	private readonly wakeRegistry = new FileWakeRegistry();
+	private readonly wakeRegistry: FileWakeRegistry;
+	private readonly timers: SupervisionTimers;
 	private timer: ReturnType<typeof setInterval> | undefined;
+	private unhealthyTimer: ReturnType<typeof setTimeout> | undefined;
 	private reconciling = false;
 	private unhealthyUntil = 0;
 	private nextGeneration = 0;
+	private closed = false;
 
 	constructor(
 		listPanes: () => Promise<PaneListSnapshot>,
 		inspectFallback: (surface: string) => Promise<PaneInspection>,
 		forcePolling = false,
+		wakeRegistry = new FileWakeRegistry(),
+		timers: SupervisionTimers = { setTimeout, clearTimeout },
 	) {
 		this.listPanes = listPanes;
 		this.inspectFallback = inspectFallback;
 		this.forcePolling = forcePolling;
+		this.wakeRegistry = wakeRegistry;
+		this.timers = timers;
 	}
 
 	register(sessionFile: string, surface: string): SupervisionRegistration {
@@ -79,6 +94,8 @@ export class SupervisionCoordinator {
 				() => this.signal(entry, "wake"),
 				() => this.enterFallback(entry),
 			);
+			entry.fileFallback = !entry.wakeRegistration.watching;
+			entry.fallback = entry.fileFallback;
 		} else {
 			entry.fallback = true;
 			entry.fileFallback = true;
@@ -104,8 +121,11 @@ export class SupervisionCoordinator {
 	}
 
 	close(): void {
+		this.closed = true;
 		if (this.timer) clearInterval(this.timer);
 		this.timer = undefined;
+		if (this.unhealthyTimer) this.timers.clearTimeout(this.unhealthyTimer);
+		this.unhealthyTimer = undefined;
 		for (const entry of this.entries) entry.wakeRegistration?.unregister();
 		this.entries.clear();
 		this.wakeRegistry.close();
@@ -114,6 +134,7 @@ export class SupervisionCoordinator {
 	private ensureTimer(): void {
 		if (this.timer) return;
 		this.timer = setInterval(() => this.reconcile(), RECONCILE_INTERVAL_MS);
+		this.timer.unref?.();
 	}
 
 	private unregister(entry: Entry): void {
@@ -126,6 +147,7 @@ export class SupervisionCoordinator {
 	}
 
 	private enterFallback(entry: Entry): void {
+		if (this.closed) return;
 		entry.fileFallback = true;
 		entry.fallback = true;
 		entry.inspection = undefined;
@@ -172,13 +194,14 @@ export class SupervisionCoordinator {
 	}
 
 	private signal(entry: Entry, reason: WakeReason): void {
+		if (this.closed) return;
 		if (reason === "wake") entry.inspection = undefined;
 		if (entry.resolve) entry.resolve(reason);
 		else entry.pending = reason;
 	}
 
 	private async reconcile(): Promise<void> {
-		if (this.reconciling || this.entries.size === 0) return;
+		if (this.closed || this.reconciling || this.entries.size === 0) return;
 		this.reconciling = true;
 		const snapshotGeneration = this.nextGeneration - 1;
 		try {
@@ -204,16 +227,22 @@ export class SupervisionCoordinator {
 				this.signal(entry, "reconcile");
 			}
 			this.unhealthyUntil = 0;
+			if (this.unhealthyTimer) this.timers.clearTimeout(this.unhealthyTimer);
+			this.unhealthyTimer = undefined;
 		} catch {
+			if (this.closed) return;
 			this.unhealthyUntil = Date.now() + BATCH_UNHEALTHY_MS;
 			for (const entry of this.entries) {
 				entry.fallback = true;
 				entry.inspection = undefined;
 				this.signal(entry, "reconcile");
 			}
-			setTimeout(() => {
-				if (Date.now() >= this.unhealthyUntil) this.reconcile();
+			if (this.unhealthyTimer) this.timers.clearTimeout(this.unhealthyTimer);
+			this.unhealthyTimer = this.timers.setTimeout(() => {
+				this.unhealthyTimer = undefined;
+				if (!this.closed && Date.now() >= this.unhealthyUntil) this.reconcile();
 			}, BATCH_UNHEALTHY_MS);
+			this.unhealthyTimer.unref?.();
 		} finally {
 			this.reconciling = false;
 		}

--- a/pi-extension/subagents/supervision.ts
+++ b/pi-extension/subagents/supervision.ts
@@ -12,7 +12,6 @@ const BATCH_UNHEALTHY_MS = 5_000;
 export interface PaneListEntry {
 	paneId: string;
 	workspaceId: string;
-	inspection: PaneInspection;
 }
 
 export interface PaneListSnapshot {
@@ -28,6 +27,7 @@ export interface SupervisionRegistration {
 
 interface Entry {
 	surface: string;
+	generation: number;
 	wakeRegistration?: WakeRegistration;
 	pending?: WakeReason;
 	resolve?: (reason: WakeReason) => void;
@@ -53,6 +53,7 @@ export class SupervisionCoordinator {
 	private timer: ReturnType<typeof setInterval> | undefined;
 	private reconciling = false;
 	private unhealthyUntil = 0;
+	private nextGeneration = 0;
 
 	constructor(
 		listPanes: () => Promise<PaneListSnapshot>,
@@ -67,6 +68,7 @@ export class SupervisionCoordinator {
 	register(sessionFile: string, surface: string): SupervisionRegistration {
 		const entry: Entry = {
 			surface,
+			generation: this.nextGeneration++,
 			fallback: this.forcePolling,
 			fileFallback: this.forcePolling,
 		};
@@ -79,6 +81,7 @@ export class SupervisionCoordinator {
 			);
 		} else {
 			entry.fallback = true;
+			entry.fileFallback = true;
 			// Forced polling retains the legacy immediate probe, then 1s cadence.
 			entry.pending = "reconcile";
 		}
@@ -177,15 +180,27 @@ export class SupervisionCoordinator {
 	private async reconcile(): Promise<void> {
 		if (this.reconciling || this.entries.size === 0) return;
 		this.reconciling = true;
+		const snapshotGeneration = this.nextGeneration - 1;
 		try {
 			const snapshot = await this.listPanes();
 			if (!snapshot.complete) throw new Error("malformed pane list");
-			const bySurface = new Map(
-				snapshot.panes.map((pane) => [pane.paneId, pane.inspection]),
-			);
+			const bySurface = new Set(snapshot.panes.map((pane) => pane.paneId));
 			for (const entry of this.entries) {
 				entry.fallback = entry.fileFallback;
-				entry.inspection = bySurface.get(entry.surface) ?? { kind: "missing" };
+				if (entry.fallback || entry.generation > snapshotGeneration) {
+					// Legacy polling and later registrants always inspect their own pane.
+					entry.inspection = undefined;
+				} else if (bySurface.has(entry.surface)) {
+					entry.inspection = {
+						kind: "present",
+						agentStatus: "unknown",
+						observedAt: Date.now(),
+					};
+				} else {
+					// A complete list can establish presence, not absence. Only pane get
+					// may establish a missing pane before completion acts on it.
+					entry.inspection = undefined;
+				}
 				this.signal(entry, "reconcile");
 			}
 			this.unhealthyUntil = 0;

--- a/pi-extension/subagents/supervision.ts
+++ b/pi-extension/subagents/supervision.ts
@@ -1,0 +1,211 @@
+import type { PaneInspection } from "./lifecycle.ts";
+import {
+	FileWakeRegistry,
+	type WakeRegistration,
+	type WakeReason,
+} from "./wake.ts";
+
+export const RECONCILE_INTERVAL_MS = 4_800;
+export const POLLING_INTERVAL_MS = 1_000;
+const BATCH_UNHEALTHY_MS = 5_000;
+
+export interface PaneListEntry {
+	paneId: string;
+	workspaceId: string;
+	inspection: PaneInspection;
+}
+
+export interface PaneListSnapshot {
+	complete: boolean;
+	panes: PaneListEntry[];
+}
+
+export interface SupervisionRegistration {
+	wait(signal: AbortSignal): Promise<WakeReason>;
+	inspectPane(): Promise<PaneInspection>;
+	unregister(): void;
+}
+
+interface Entry {
+	surface: string;
+	wakeRegistration?: WakeRegistration;
+	pending?: WakeReason;
+	resolve?: (reason: WakeReason) => void;
+	inspection?: PaneInspection;
+	fallback: boolean;
+	fileFallback: boolean;
+}
+
+export interface SupervisionDiagnostics {
+	mode: "wake+batch" | "polling(forced)" | "polling(fallback)";
+	watcherCount: number;
+}
+
+/** A runtime-owned coordinator for file wake-ups and shared pane snapshots. */
+export class SupervisionCoordinator {
+	private readonly entries = new Set<Entry>();
+	private readonly listPanes: () => Promise<PaneListSnapshot>;
+	private readonly inspectFallback: (
+		surface: string,
+	) => Promise<PaneInspection>;
+	private readonly forcePolling: boolean;
+	private readonly wakeRegistry = new FileWakeRegistry();
+	private timer: ReturnType<typeof setInterval> | undefined;
+	private reconciling = false;
+	private unhealthyUntil = 0;
+
+	constructor(
+		listPanes: () => Promise<PaneListSnapshot>,
+		inspectFallback: (surface: string) => Promise<PaneInspection>,
+		forcePolling = false,
+	) {
+		this.listPanes = listPanes;
+		this.inspectFallback = inspectFallback;
+		this.forcePolling = forcePolling;
+	}
+
+	register(sessionFile: string, surface: string): SupervisionRegistration {
+		const entry: Entry = {
+			surface,
+			fallback: this.forcePolling,
+			fileFallback: this.forcePolling,
+		};
+		this.entries.add(entry);
+		if (!this.forcePolling && process.platform !== "win32") {
+			entry.wakeRegistration = this.wakeRegistry.register(
+				sessionFile,
+				() => this.signal(entry, "wake"),
+				() => this.enterFallback(entry),
+			);
+		} else {
+			entry.fallback = true;
+			// Forced polling retains the legacy immediate probe, then 1s cadence.
+			entry.pending = "reconcile";
+		}
+		this.ensureTimer();
+		if (!this.forcePolling) this.reconcile();
+		return {
+			wait: (signal) => this.wait(entry, signal),
+			inspectPane: () => this.inspect(entry),
+			unregister: () => this.unregister(entry),
+		};
+	}
+
+	diagnostics(): SupervisionDiagnostics {
+		const mode = this.forcePolling
+			? "polling(forced)"
+			: [...this.entries].some((entry) => entry.fallback)
+				? "polling(fallback)"
+				: "wake+batch";
+		return { mode, watcherCount: this.wakeRegistry.watcherCount };
+	}
+
+	close(): void {
+		if (this.timer) clearInterval(this.timer);
+		this.timer = undefined;
+		for (const entry of this.entries) entry.wakeRegistration?.unregister();
+		this.entries.clear();
+		this.wakeRegistry.close();
+	}
+
+	private ensureTimer(): void {
+		if (this.timer) return;
+		this.timer = setInterval(() => this.reconcile(), RECONCILE_INTERVAL_MS);
+	}
+
+	private unregister(entry: Entry): void {
+		entry.wakeRegistration?.unregister();
+		this.entries.delete(entry);
+		if (this.entries.size === 0 && this.timer) {
+			clearInterval(this.timer);
+			this.timer = undefined;
+		}
+	}
+
+	private enterFallback(entry: Entry): void {
+		entry.fileFallback = true;
+		entry.fallback = true;
+		entry.inspection = undefined;
+		this.signal(entry, "reconcile");
+	}
+
+	private wait(entry: Entry, signal: AbortSignal): Promise<WakeReason> {
+		if (signal.aborted)
+			return Promise.reject(
+				new Error("Aborted while waiting for subagent to finish"),
+			);
+		if (entry.pending) {
+			const reason = entry.pending;
+			entry.pending = undefined;
+			return Promise.resolve(reason);
+		}
+		if (entry.fallback) return this.poll(signal);
+		return new Promise((resolve, reject) => {
+			const onAbort = () => {
+				entry.resolve = undefined;
+				reject(new Error("Aborted while waiting for subagent to finish"));
+			};
+			entry.resolve = (reason) => {
+				signal.removeEventListener("abort", onAbort);
+				entry.resolve = undefined;
+				resolve(reason);
+			};
+			signal.addEventListener("abort", onAbort, { once: true });
+		});
+	}
+
+	private poll(signal: AbortSignal): Promise<WakeReason> {
+		return new Promise((resolve, reject) => {
+			const timer = setTimeout(() => {
+				signal.removeEventListener("abort", onAbort);
+				resolve("reconcile");
+			}, POLLING_INTERVAL_MS);
+			const onAbort = () => {
+				clearTimeout(timer);
+				reject(new Error("Aborted while waiting for subagent to finish"));
+			};
+			signal.addEventListener("abort", onAbort, { once: true });
+		});
+	}
+
+	private signal(entry: Entry, reason: WakeReason): void {
+		if (reason === "wake") entry.inspection = undefined;
+		if (entry.resolve) entry.resolve(reason);
+		else entry.pending = reason;
+	}
+
+	private async reconcile(): Promise<void> {
+		if (this.reconciling || this.entries.size === 0) return;
+		this.reconciling = true;
+		try {
+			const snapshot = await this.listPanes();
+			if (!snapshot.complete) throw new Error("malformed pane list");
+			const bySurface = new Map(
+				snapshot.panes.map((pane) => [pane.paneId, pane.inspection]),
+			);
+			for (const entry of this.entries) {
+				entry.fallback = entry.fileFallback;
+				entry.inspection = bySurface.get(entry.surface) ?? { kind: "missing" };
+				this.signal(entry, "reconcile");
+			}
+			this.unhealthyUntil = 0;
+		} catch {
+			this.unhealthyUntil = Date.now() + BATCH_UNHEALTHY_MS;
+			for (const entry of this.entries) {
+				entry.fallback = true;
+				entry.inspection = undefined;
+				this.signal(entry, "reconcile");
+			}
+			setTimeout(() => {
+				if (Date.now() >= this.unhealthyUntil) this.reconcile();
+			}, BATCH_UNHEALTHY_MS);
+		} finally {
+			this.reconciling = false;
+		}
+	}
+
+	private async inspect(entry: Entry): Promise<PaneInspection> {
+		if (entry.inspection) return entry.inspection;
+		return this.inspectFallback(entry.surface);
+	}
+}

--- a/pi-extension/subagents/terminal.ts
+++ b/pi-extension/subagents/terminal.ts
@@ -15,6 +15,7 @@ import {
 	readHerdrScreen,
 	readHerdrScreenAsync,
 	inspectHerdrPane,
+	listHerdrPanes,
 	renameHerdrTab,
 	renameHerdrWorkspace,
 	sendHerdrCommand,
@@ -136,6 +137,13 @@ export async function readPaneAsync(
 }
 
 export type { PaneInspection, HerdrAgentStatus } from "./lifecycle.ts";
+
+export async function listPanes(): Promise<
+	import("./herdr.ts").HerdrPaneListEntry[] | null
+> {
+	assertTerminalAvailable();
+	return listHerdrPanes();
+}
 
 export async function inspectPane(
 	paneId: PaneId,

--- a/pi-extension/subagents/wake.ts
+++ b/pi-extension/subagents/wake.ts
@@ -15,15 +15,22 @@ interface DirectoryWatcher {
 }
 
 export interface WakeRegistration {
+	watching: boolean;
 	unregister(): void;
 }
 
 /**
- * Shares directory watches between supervised sessions. Writers publish with
- * rename, so directories (rather than sidecar files) are watched deliberately.
+ * Shares directory watches between supervised sessions. Sidecars use atomic
+ * rename and task events use appendFileSync, so directories are watched deliberately.
  */
 export class FileWakeRegistry {
 	private readonly directories = new Map<string, DirectoryWatcher>();
+	private readonly watchDirectory: typeof watch;
+	private closed = false;
+
+	constructor(watchDirectory: typeof watch = watch) {
+		this.watchDirectory = watchDirectory;
+	}
 
 	register(
 		sessionFile: string,
@@ -40,16 +47,17 @@ export class FileWakeRegistry {
 			fallback,
 		};
 		let current = this.directories.get(directory);
-		if (!current) {
+		if (!this.closed && !current) {
 			try {
-				const watcher = watch(directory, (_event, filename) => {
-					if (!filename) return;
-					const name = filename.toString();
+				const watcher = this.watchDirectory(directory, (_event, filename) => {
+					if (this.closed) return;
 					for (const watched of current?.entries ?? []) {
-						if (watched.filenames.has(name)) watched.wake();
+						if (!filename || watched.filenames.has(filename.toString()))
+							watched.wake();
 					}
 				});
 				current = { watcher, entries: new Set() };
+				watcher.unref();
 				watcher.on("error", () => this.failDirectory(directory));
 				this.directories.set(directory, current);
 			} catch {
@@ -60,6 +68,7 @@ export class FileWakeRegistry {
 		else fallback();
 
 		return {
+			watching: current != null,
 			unregister: () => {
 				const active = this.directories.get(directory);
 				if (!active) return;
@@ -77,11 +86,13 @@ export class FileWakeRegistry {
 	}
 
 	close(): void {
+		this.closed = true;
 		for (const { watcher } of this.directories.values()) watcher.close();
 		this.directories.clear();
 	}
 
 	private failDirectory(directory: string): void {
+		if (this.closed) return;
 		const current = this.directories.get(directory);
 		if (!current) return;
 		this.directories.delete(directory);

--- a/pi-extension/subagents/wake.ts
+++ b/pi-extension/subagents/wake.ts
@@ -1,0 +1,91 @@
+import { watch, type FSWatcher } from "node:fs";
+import { basename, dirname } from "node:path";
+
+export type WakeReason = "wake" | "reconcile";
+
+interface WakeEntry {
+	filenames: Set<string>;
+	wake: () => void;
+	fallback: () => void;
+}
+
+interface DirectoryWatcher {
+	watcher: FSWatcher;
+	entries: Set<WakeEntry>;
+}
+
+export interface WakeRegistration {
+	unregister(): void;
+}
+
+/**
+ * Shares directory watches between supervised sessions. Writers publish with
+ * rename, so directories (rather than sidecar files) are watched deliberately.
+ */
+export class FileWakeRegistry {
+	private readonly directories = new Map<string, DirectoryWatcher>();
+
+	register(
+		sessionFile: string,
+		wake: () => void,
+		fallback: () => void,
+	): WakeRegistration {
+		const directory = dirname(sessionFile);
+		const entry: WakeEntry = {
+			filenames: new Set([
+				`${basename(sessionFile)}.exit`,
+				`${basename(sessionFile)}.tasks`,
+			]),
+			wake,
+			fallback,
+		};
+		let current = this.directories.get(directory);
+		if (!current) {
+			try {
+				const watcher = watch(directory, (_event, filename) => {
+					if (!filename) return;
+					const name = filename.toString();
+					for (const watched of current?.entries ?? []) {
+						if (watched.filenames.has(name)) watched.wake();
+					}
+				});
+				current = { watcher, entries: new Set() };
+				watcher.on("error", () => this.failDirectory(directory));
+				this.directories.set(directory, current);
+			} catch {
+				// The caller switches this child to polling.
+			}
+		}
+		if (current) current.entries.add(entry);
+		else fallback();
+
+		return {
+			unregister: () => {
+				const active = this.directories.get(directory);
+				if (!active) return;
+				active.entries.delete(entry);
+				if (active.entries.size === 0) {
+					active.watcher.close();
+					this.directories.delete(directory);
+				}
+			},
+		};
+	}
+
+	get watcherCount(): number {
+		return this.directories.size;
+	}
+
+	close(): void {
+		for (const { watcher } of this.directories.values()) watcher.close();
+		this.directories.clear();
+	}
+
+	private failDirectory(directory: string): void {
+		const current = this.directories.get(directory);
+		if (!current) return;
+		this.directories.delete(directory);
+		current.watcher.close();
+		for (const entry of current.entries) entry.fallback();
+	}
+}

--- a/test/bench/README.md
+++ b/test/bench/README.md
@@ -1,0 +1,14 @@
+# Supervision benchmark
+
+Run this manual benchmark from inside Herdr:
+
+```bash
+node --experimental-strip-types test/bench/supervision-bench.mjs
+```
+
+It creates an isolated Herdr server, scratch HOME, held child panes, and a
+PATH-first `herdr` logging shim. It runs 20-second steady-state windows for
+1, 5, and 10 children (three rotated rounds at 10) and writes raw samples plus
+gate results to `/tmp/issue29-bench/`. It is intentionally excluded from
+`npm test` and the npm tarball. The benchmark cleans only its own server,
+workspace, panes, and scratch directory.

--- a/test/bench/supervision-bench.mjs
+++ b/test/bench/supervision-bench.mjs
@@ -1,0 +1,384 @@
+#!/usr/bin/env node
+/**
+ * Manual coordinator benchmark. It owns an isolated Herdr server and never
+ * touches the caller's HOME, workspace, or test resources.
+ */
+import assert from "node:assert/strict";
+import { execFile, execFileSync, spawn } from "node:child_process";
+import {
+	mkdtemp,
+	mkdir,
+	readFile,
+	readdir,
+	rm,
+	writeFile,
+} from "node:fs/promises";
+import { readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { setTimeout as delay } from "node:timers/promises";
+import { SupervisionCoordinator } from "../../pi-extension/subagents/supervision.ts";
+import { waitForCompletion } from "../../pi-extension/subagents/completion.ts";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(HERE, "../..");
+const WINDOW_MS = 20_000;
+const SIZES = [1, 5, 10];
+const REAL_HERDR =
+	process.env.HERDR_BIN ??
+	execFileSync("sh", ["-c", "command -v herdr"], { encoding: "utf8" }).trim();
+const output = process.env.ISSUE29_BENCH_OUT ?? "/tmp/issue29-bench";
+const now = () => Number(process.hrtime.bigint()) / 1e6;
+
+function command(file, args, env, timeout = 10_000) {
+	return new Promise((resolve, reject) => {
+		const child = execFile(
+			file,
+			args,
+			{ env, timeout, encoding: "utf8" },
+			(error, stdout, stderr) => {
+				if (error)
+					reject(
+						new Error(`${file} ${args.join(" ")}: ${stderr || error.message}`),
+					);
+				else resolve(stdout);
+			},
+		);
+		child.unref?.();
+	});
+}
+
+async function until(condition, timeoutMs, label) {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (await condition()) return;
+		await delay(50);
+	}
+	throw new Error(`Timed out waiting for ${label}`);
+}
+
+function stat(pid) {
+	try {
+		const columns = readFileSync(`/proc/${pid}/stat`, "utf8")
+			.slice(readFileSync(`/proc/${pid}/stat`, "utf8").lastIndexOf(")") + 2)
+			.split(" ");
+		return {
+			pid: Number(pid),
+			parent: Number(columns[1]),
+			ticks:
+				Number(columns[11]) +
+				Number(columns[12]) +
+				Number(columns[13]) +
+				Number(columns[14]),
+		};
+	} catch {
+		return null;
+	}
+}
+
+async function cpuSnapshot(serverPid) {
+	const all = (await readdir("/proc"))
+		.filter((name) => /^\d+$/.test(name))
+		.map(stat)
+		.filter(Boolean);
+	const owned = new Set([serverPid]);
+	for (let changed = true; changed; ) {
+		changed = false;
+		for (const entry of all)
+			if (owned.has(entry.parent) && !owned.has(entry.pid)) {
+				owned.add(entry.pid);
+				changed = true;
+			}
+	}
+	return {
+		supervisorTicks: stat(process.pid)?.ticks ?? 0,
+		herdrTreeTicks: all
+			.filter((entry) => owned.has(entry.pid))
+			.reduce((sum, entry) => sum + entry.ticks, 0),
+	};
+}
+
+async function createLab() {
+	const root = await mkdtemp(join(tmpdir(), "issue29-bench-"));
+	const home = join(root, "home");
+	const socket = join(home, ".config/herdr/sessions/issue29-bench/herdr.sock");
+	const config = join(root, "config.toml");
+	await mkdir(dirname(socket), { recursive: true });
+	await writeFile(
+		config,
+		'onboarding = false\n[terminal]\ndefault_shell = "/bin/bash"\nshell_mode = "non_login"\n[update]\nversion_check = false\nmanifest_check = false\n[ui.sound]\nenabled = false\n[ui.toast]\ndelivery = "off"\n[experimental]\nallow_nested = true\n',
+	);
+	await writeFile(join(dirname(socket), "config.toml"), await readFile(config));
+	const calls = join(root, "herdr-calls.jsonl");
+	const shim = join(root, "bin");
+	await mkdir(shim);
+	await writeFile(
+		join(shim, "herdr"),
+		`#!/bin/sh\nprintf '{"at":%s,"argv":"%s"}\\n' "$(date +%s%N)" "$*" >> ${JSON.stringify(calls)}\nexec ${JSON.stringify(REAL_HERDR)} "$@"\n`,
+		{ mode: 0o755 },
+	);
+	const env = {
+		...process.env,
+		HOME: home,
+		PATH: `${shim}:${process.env.PATH}`,
+		XDG_CONFIG_HOME: join(home, ".config"),
+		XDG_DATA_HOME: join(home, ".local/share"),
+		XDG_STATE_HOME: join(home, ".local/state"),
+		HERDR_CONFIG_PATH: config,
+		HERDR_SOCKET_PATH: socket,
+		PI_OFFLINE: "1",
+	};
+	const server = spawn(REAL_HERDR, ["--session", "issue29-bench", "server"], {
+		env,
+		stdio: "ignore",
+	});
+	const cli = (args) => command("herdr", args, env);
+	try {
+		await until(
+			async () => {
+				try {
+					await cli(["workspace", "list"]);
+					return true;
+				} catch {
+					return false;
+				}
+			},
+			15_000,
+			"isolated Herdr startup",
+		);
+		const created = JSON.parse(
+			await cli([
+				"workspace",
+				"create",
+				"--cwd",
+				ROOT,
+				"--label",
+				"issue29 benchmark",
+				"--no-focus",
+			]),
+		);
+		return {
+			root,
+			env,
+			server,
+			cli,
+			calls,
+			workspace: created.result.workspace.workspace_id,
+		};
+	} catch (error) {
+		server.kill("SIGTERM");
+		await rm(root, { recursive: true, force: true });
+		throw error;
+	}
+}
+
+async function closeLab(lab) {
+	try {
+		await lab.cli(["server", "stop"]);
+	} catch {}
+	if (lab.server.exitCode === null) lab.server.kill("SIGTERM");
+	await rm(lab.root, { recursive: true, force: true });
+}
+
+async function makeChildren(lab, count, sequence) {
+	const children = [];
+	for (let index = 0; index < count; index++) {
+		const created = JSON.parse(
+			await lab.cli([
+				"tab",
+				"create",
+				"--workspace",
+				lab.workspace,
+				"--cwd",
+				lab.root,
+				"--label",
+				`held-${sequence}-${index}`,
+				"--no-focus",
+			]),
+		);
+		const pane = created.result.root_pane.pane_id;
+		await lab.cli(["pane", "run", pane, "sleep 300"]);
+		const session = join(lab.root, `held-${sequence}-${index}.jsonl`);
+		await writeFile(session, "{}\n");
+		children.push({ pane, session, probes: [], evidenceAt: 0, resolvedAt: 0 });
+	}
+	return children;
+}
+
+async function trial(lab, mode, count, round, sequence) {
+	const children = await makeChildren(lab, count, sequence);
+	const hz = Number((await command("getconf", ["CLK_TCK"], lab.env)).trim());
+	const coordinator = new SupervisionCoordinator(
+		async () => {
+			const reply = JSON.parse(await lab.cli(["pane", "list"]));
+			const panes = reply.result?.panes;
+			if (!Array.isArray(panes)) return { complete: false, panes: [] };
+			return {
+				complete: true,
+				panes: panes.map((pane) => ({
+					paneId: pane.pane_id,
+					workspaceId: pane.workspace_id,
+					inspection: { kind: "present", observedAt: Date.now() },
+				})),
+			};
+		},
+		async (pane) => {
+			const reply = JSON.parse(await lab.cli(["pane", "get", pane]));
+			return reply.result?.pane
+				? { kind: "present", observedAt: Date.now() }
+				: { kind: "missing" };
+		},
+		mode === "baseline",
+	);
+	const watches = children.map((child) => {
+		const registration = coordinator.register(child.session, child.pane);
+		const promise = waitForCompletion(new AbortController().signal, {
+			intervalMs: 1_000,
+			sessionFile: child.session,
+			waitForNextCheck: registration.wait,
+			inspectPane: registration.inspectPane,
+			readTerminalTail: async () => {
+				child.probes.push(now());
+				return lab.cli([
+					"pane",
+					"read",
+					child.pane,
+					"--source",
+					"visible",
+					"--lines",
+					"5",
+				]);
+			},
+		}).then((result) => {
+			child.resolvedAt = now();
+			return result;
+		});
+		return { registration, promise };
+	});
+	try {
+		await delay(1_000); // Let initial reconciliation settle before the window.
+		await writeFile(lab.calls, "");
+		const before = await cpuSnapshot(lab.server.pid);
+		const startedAt = now();
+		await delay(WINDOW_MS);
+		const after = await cpuSnapshot(lab.server.pid);
+		const elapsed = now() - startedAt;
+		for (const child of children) {
+			child.evidenceAt = now();
+			await writeFile(
+				`${child.session}.exit.tmp`,
+				JSON.stringify({ type: "done" }),
+			);
+			await command(
+				"mv",
+				[`${child.session}.exit.tmp`, `${child.session}.exit`],
+				lab.env,
+			);
+		}
+		const outcomes = await Promise.all(watches.map((watch) => watch.promise));
+		assert.ok(outcomes.every((result) => result.reason === "done"));
+		const calls = (await readFile(lab.calls, "utf8"))
+			.trim()
+			.split("\n")
+			.filter(Boolean)
+			.map(JSON.parse);
+		const latencies = children.map(
+			(child) => child.resolvedAt - child.evidenceAt,
+		);
+		const gaps = children.flatMap((child) =>
+			child.probes.slice(1).map((at, index) => at - child.probes[index]),
+		);
+		return {
+			mode,
+			count,
+			round,
+			windowMs: elapsed,
+			cliLaunches: calls.length,
+			cliLaunchesPerSecond: (calls.length * 1000) / elapsed,
+			supervisionCpuMs:
+				((after.supervisorTicks - before.supervisorTicks) * 1000) / hz,
+			herdrTreeCpuMs:
+				((after.herdrTreeTicks - before.herdrTreeTicks) * 1000) / hz,
+			detectionLatencyMs: latencies,
+			maxProbeGapMs: Math.max(0, ...gaps),
+			calls,
+		};
+	} finally {
+		for (const watch of watches) watch.registration.unregister();
+		coordinator.close();
+		for (const child of children)
+			try {
+				await lab.cli(["pane", "close", child.pane]);
+			} catch {}
+	}
+}
+
+await mkdir(output, { recursive: true });
+const lab = await createLab();
+const results = [];
+try {
+	let sequence = 0;
+	for (const count of SIZES) {
+		const rounds = count === 10 ? 3 : 1;
+		for (let round = 0; round < rounds; round++) {
+			for (const mode of round % 2
+				? ["wake+batch", "baseline"]
+				: ["baseline", "wake+batch"]) {
+				const result = await trial(lab, mode, count, round, sequence++);
+				results.push(result);
+				const { calls: _calls, ...summary } = result;
+				console.log(JSON.stringify(summary));
+			}
+		}
+	}
+	await writeFile(
+		join(output, "results.json"),
+		JSON.stringify(
+			{
+				conditions: {
+					windowMs: WINDOW_MS,
+					sizes: SIZES,
+					roundsAtTen: 3,
+					cpu: "Linux /proc ticks for benchmark supervisor and isolated Herdr tree",
+					latency: "sidecar publication to waitForCompletion resolver return",
+					children: "isolated Herdr panes held in sleep 300",
+				},
+				results,
+			},
+			null,
+			2,
+		),
+	);
+	const by = (mode, count) =>
+		results.filter((result) => result.mode === mode && result.count === count);
+	const average = (values, key) =>
+		values.reduce((sum, value) => sum + value[key], 0) / values.length;
+	const averageLatency = (values) => {
+		const samples = values.flatMap((value) => value.detectionLatencyMs);
+		return samples.reduce((sum, sample) => sum + sample, 0) / samples.length;
+	};
+	const baseline = by("baseline", 10);
+	const wake = by("wake+batch", 10);
+	const reduction =
+		1 -
+		average(wake, "cliLaunchesPerSecond") /
+			average(baseline, "cliLaunchesPerSecond");
+	const gates = {
+		recurringCliReductionAtTen: reduction >= 0.8,
+		noCpuRegression:
+			average(wake, "supervisionCpuMs") <=
+			average(baseline, "supervisionCpuMs"),
+		noLatencyRegression: averageLatency(wake) <= averageLatency(baseline),
+		maxReconcileGap:
+			Math.max(...wake.map((result) => result.maxProbeGapMs)) < 5_000,
+	};
+	await writeFile(
+		join(output, "summary.json"),
+		JSON.stringify({ reduction, gates }, null, 2),
+	);
+	console.log(JSON.stringify({ output, reduction, gates }));
+	if (!Object.values(gates).every(Boolean)) process.exitCode = 1;
+} finally {
+	await closeLab(lab);
+}

--- a/test/integration/supervision.test.ts
+++ b/test/integration/supervision.test.ts
@@ -10,6 +10,7 @@
  */
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import * as subagentsModule from "../../pi-extension/subagents/index.ts";
 import {
 	mkdtempSync,
 	mkdirSync,
@@ -137,6 +138,11 @@ describe("event-driven supervision integration", { timeout: 30_000 }, () => {
 			const registration = supervisor.register(sessionFile, "child-pane");
 			try {
 				let deliveries = 0;
+				const deliveryApi = {
+					sendMessage() {
+						deliveries += 1;
+					},
+				};
 				const completion = waitForCompletion(new AbortController().signal, {
 					intervalMs: POLLING_INTERVAL_MS,
 					sessionFile,
@@ -147,10 +153,14 @@ describe("event-driven supervision integration", { timeout: 30_000 }, () => {
 				await sleep(35);
 				publishSidecar(sessionFile, { type: "done" });
 				assert.equal((await completion).reason, "done");
-				deliveries += 1;
+				subagentsModule.__test__.sendSubagentResult(
+					deliveryApi,
+					"Subagent completed.",
+					{ name: "child" },
+				);
 
 				// A second atomic publish is a legal late watcher event. The resolved
-				// completion is never re-delivered.
+				// completion does not invoke the real parent delivery path again.
 				publishSidecar(sessionFile, { type: "done" });
 				await sleep(50);
 				assert.equal(deliveries, 1);

--- a/test/integration/supervision.test.ts
+++ b/test/integration/supervision.test.ts
@@ -1,0 +1,323 @@
+/**
+ * Deterministic component integration for the completion, file-wake, and
+ * shared-reconciliation seams. Real parent/child lifecycle coverage remains in
+ * subagent-lifecycle.test.ts and persistent-specialist.test.ts.
+ *
+ * A real Pi parent cannot deterministically publish an error or caller_ping
+ * sidecar in the same event-loop turn as a terminal read. The unit reproducer
+ * in test/test.ts covers that semantic race; this file verifies normal
+ * supervision transport behavior without timing a provider response.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+	mkdtempSync,
+	mkdirSync,
+	renameSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { waitForCompletion } from "../../pi-extension/subagents/completion.ts";
+import {
+	POLLING_INTERVAL_MS,
+	RECONCILE_INTERVAL_MS,
+	SupervisionCoordinator,
+} from "../../pi-extension/subagents/supervision.ts";
+import {
+	appendPersistentTaskEvent,
+	readPersistentTaskEvents,
+} from "../../pi-extension/subagents/session.ts";
+
+const RECONCILE_BUDGET_MS = RECONCILE_INTERVAL_MS + 700;
+
+type SidecarPayload =
+	| { type: "done" }
+	| { type: "error"; errorMessage: string }
+	| { type: "ping"; name: string; message: string };
+
+function sleep(milliseconds: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function eventually(
+	predicate: () => boolean,
+	description: string,
+	timeoutMs = 2_000,
+): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (predicate()) return;
+		await sleep(10);
+	}
+	throw new Error(`Timed out waiting for ${description}`);
+}
+
+function publishSidecar(sessionFile: string, payload: SidecarPayload): void {
+	const temporary = `${sessionFile}.exit.tmp`;
+	writeFileSync(temporary, JSON.stringify(payload));
+	renameSync(temporary, `${sessionFile}.exit`);
+}
+
+function makeSupervisor(
+	forcePolling = false,
+	shouldFailList: () => boolean = () => false,
+) {
+	let fallbackCount = 0;
+	return {
+		supervisor: new SupervisionCoordinator(
+			async () => {
+				if (shouldFailList()) throw new Error("pane list unavailable");
+				return {
+					complete: true,
+					panes: [
+						{
+							paneId: "child-pane",
+							workspaceId: "test-workspace",
+							inspection: {
+								kind: "present",
+								agentStatus: "idle",
+								observedAt: Date.now(),
+							},
+						},
+					],
+				};
+			},
+			async () => {
+				fallbackCount += 1;
+				return {
+					kind: "present",
+					agentStatus: "idle",
+					observedAt: Date.now(),
+				};
+			},
+			forcePolling,
+		),
+		fallbackInspections: () => fallbackCount,
+	};
+}
+
+async function watchOutcome(
+	sessionFile: string,
+	forcePolling: boolean,
+	payload: SidecarPayload,
+): Promise<{ reason: string; elapsedMs: number; mode: string }> {
+	const { supervisor } = makeSupervisor(forcePolling);
+	const registration = supervisor.register(sessionFile, "child-pane");
+	try {
+		const startedAt = Date.now();
+		const completion = waitForCompletion(new AbortController().signal, {
+			intervalMs: POLLING_INTERVAL_MS,
+			sessionFile,
+			readTerminalTail: async () => "",
+			inspectPane: registration.inspectPane,
+			waitForNextCheck: registration.wait,
+		});
+		await sleep(35);
+		publishSidecar(sessionFile, payload);
+		const result = await completion;
+		return {
+			reason: result.reason,
+			elapsedMs: Date.now() - startedAt,
+			mode: supervisor.diagnostics().mode,
+		};
+	} finally {
+		registration.unregister();
+		supervisor.close();
+	}
+}
+
+describe("event-driven supervision integration", { timeout: 30_000 }, () => {
+	it("delivers an ordinary child once despite duplicate late file wakes", async () => {
+		const root = mkdtempSync(join(tmpdir(), "pi-supervision-integ-"));
+		try {
+			const sessionFile = join(root, "child.jsonl");
+			const { supervisor } = makeSupervisor();
+			const registration = supervisor.register(sessionFile, "child-pane");
+			try {
+				let deliveries = 0;
+				const completion = waitForCompletion(new AbortController().signal, {
+					intervalMs: POLLING_INTERVAL_MS,
+					sessionFile,
+					readTerminalTail: async () => "",
+					inspectPane: registration.inspectPane,
+					waitForNextCheck: registration.wait,
+				});
+				await sleep(35);
+				publishSidecar(sessionFile, { type: "done" });
+				assert.equal((await completion).reason, "done");
+				deliveries += 1;
+
+				// A second atomic publish is a legal late watcher event. The resolved
+				// completion is never re-delivered.
+				publishSidecar(sessionFile, { type: "done" });
+				await sleep(50);
+				assert.equal(deliveries, 1);
+			} finally {
+				registration.unregister();
+				supervisor.close();
+			}
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("folds persistent .tasks wakes while idle, then stops after task two", async () => {
+		const root = mkdtempSync(join(tmpdir(), "pi-supervision-persistent-"));
+		try {
+			const sessionFile = join(root, "specialist.jsonl");
+			writeFileSync(sessionFile, "{}\n");
+			const { supervisor } = makeSupervisor();
+			const registration = supervisor.register(sessionFile, "child-pane");
+			try {
+				const delivered: string[] = [];
+				let observed = 0;
+				const completion = waitForCompletion(new AbortController().signal, {
+					intervalMs: POLLING_INTERVAL_MS,
+					sessionFile,
+					readTerminalTail: async () => "",
+					inspectPane: registration.inspectPane,
+					waitForNextCheck: registration.wait,
+					onLocalEvidence: () => {
+						const events = readPersistentTaskEvents(sessionFile);
+						for (const event of events.slice(observed))
+							delivered.push(event.task);
+						observed = events.length;
+					},
+				});
+				await sleep(35);
+				appendPersistentTaskEvent(sessionFile, {
+					type: "task-done",
+					task: "task-1",
+					generation: "generation",
+				});
+				await eventually(() => delivered.length === 1, "task 1 delivery");
+				await sleep(50); // The specialist is idle, not terminal, between tasks.
+				appendPersistentTaskEvent(sessionFile, {
+					type: "task-done",
+					task: "task-2",
+					generation: "generation",
+				});
+				await eventually(() => delivered.length === 2, "task 2 delivery");
+				publishSidecar(sessionFile, { type: "done" });
+				assert.equal((await completion).reason, "done");
+				assert.deepEqual(delivered, ["task-1", "task-2"]);
+			} finally {
+				registration.unregister();
+				supervisor.close();
+			}
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("reconciles dropped file notifications within the five-second budget", async () => {
+		const root = mkdtempSync(join(tmpdir(), "pi-supervision-reconcile-"));
+		const oldRoot = `${root}-old`;
+		try {
+			const sessionFile = join(root, "child.jsonl");
+			const { supervisor } = makeSupervisor();
+			const registration = supervisor.register(sessionFile, "child-pane");
+			try {
+				// Consume the registration's initial snapshot. Replacing the watched
+				// directory drops subsequent fs notifications without making pane
+				// inspection evidence unavailable.
+				await registration.wait(new AbortController().signal);
+				await registration.inspectPane();
+				renameSync(root, oldRoot);
+				mkdirSync(root);
+				const startedAt = Date.now();
+				const completion = waitForCompletion(new AbortController().signal, {
+					intervalMs: POLLING_INTERVAL_MS,
+					sessionFile,
+					readTerminalTail: async () => "",
+					inspectPane: registration.inspectPane,
+					waitForNextCheck: registration.wait,
+				});
+				publishSidecar(sessionFile, { type: "done" });
+				assert.equal((await completion).reason, "done");
+				assert.ok(Date.now() - startedAt < RECONCILE_BUDGET_MS);
+			} finally {
+				registration.unregister();
+				supervisor.close();
+			}
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+			rmSync(oldRoot, { recursive: true, force: true });
+		}
+	});
+
+	it("falls back to polling after watcher failure without an extra parent steer", async () => {
+		const root = mkdtempSync(join(tmpdir(), "pi-supervision-fallback-"));
+		try {
+			const sessionFile = join(root, "child.jsonl");
+			let failLists = false;
+			const { supervisor, fallbackInspections } = makeSupervisor(
+				false,
+				() => failLists,
+			);
+			const registration = supervisor.register(sessionFile, "child-pane");
+			try {
+				await registration.wait(new AbortController().signal);
+				failLists = true;
+				const parentSteers: string[] = [];
+				const completion = waitForCompletion(new AbortController().signal, {
+					intervalMs: POLLING_INTERVAL_MS,
+					sessionFile,
+					readTerminalTail: async () => "",
+					inspectPane: registration.inspectPane,
+					waitForNextCheck: registration.wait,
+				});
+
+				// The next batch failure switches this registration to the legacy
+				// cadence. A transport transition is internal and has no parent API.
+				await eventually(
+					() => supervisor.diagnostics().mode === "polling(fallback)",
+					"polling fallback",
+					RECONCILE_INTERVAL_MS + 1_000,
+				);
+				await eventually(
+					() => fallbackInspections() > 0,
+					"legacy fallback inspection",
+					POLLING_INTERVAL_MS + 1_000,
+				);
+				publishSidecar(sessionFile, { type: "done" });
+				assert.equal((await completion).reason, "done");
+				assert.deepEqual(parentSteers, []);
+			} finally {
+				registration.unregister();
+				supervisor.close();
+			}
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps forcePolling outcomes identical for done, error, and ping evidence", async () => {
+		for (const forcePolling of [false, true]) {
+			for (const payload of [
+				{ type: "done" },
+				{ type: "error", errorMessage: "provider failed" },
+				{ type: "ping", name: "child", message: "help" },
+			] as const) {
+				const root = mkdtempSync(join(tmpdir(), "pi-supervision-outcome-"));
+				try {
+					const result = await watchOutcome(
+						join(root, "child.jsonl"),
+						forcePolling,
+						payload,
+					);
+					assert.equal(result.reason, payload.type);
+					assert.match(
+						result.mode,
+						forcePolling ? /polling\(forced\)/ : /wake\+batch/,
+					);
+					assert.ok(result.elapsedMs < 2_500);
+				} finally {
+					rmSync(root, { recursive: true, force: true });
+				}
+			}
+		}
+	});
+});

--- a/test/test.ts
+++ b/test/test.ts
@@ -1962,6 +1962,74 @@ describe("supervision", () => {
 		}
 	});
 
+	it("does not apply an in-flight snapshot to a child registered after it began", async () => {
+		let resolveList:
+			| ((snapshot: {
+					complete: boolean;
+					panes: Array<{
+						paneId: string;
+						workspaceId: string;
+					}>;
+			  }) => void)
+			| undefined;
+		let fallbackInspections = 0;
+		const supervisor = new SupervisionCoordinator(
+			() =>
+				new Promise((resolve) => {
+					resolveList = resolve;
+				}),
+			async () => {
+				fallbackInspections += 1;
+				return { kind: "present", agentStatus: "idle", observedAt: Date.now() };
+			},
+		);
+		const dir = createTestDir();
+		try {
+			const one = supervisor.register(join(dir, "one.jsonl"), "one");
+			const two = supervisor.register(join(dir, "two.jsonl"), "two");
+			resolveList?.({
+				complete: true,
+				panes: [{ paneId: "one", workspaceId: "workspace" }],
+			});
+			await Promise.all([
+				one.wait(new AbortController().signal),
+				two.wait(new AbortController().signal),
+			]);
+			assert.equal((await two.inspectPane()).kind, "present");
+			assert.equal(fallbackInspections, 1);
+			one.unregister();
+			two.unregister();
+		} finally {
+			supervisor.close();
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("confirms empty complete-list absence with a pane inspection", async () => {
+		let fallbackInspections = 0;
+		const supervisor = new SupervisionCoordinator(
+			async () => ({ complete: true, panes: [] }),
+			async () => {
+				fallbackInspections += 1;
+				return { kind: "present", agentStatus: "idle", observedAt: Date.now() };
+			},
+		);
+		const dir = createTestDir();
+		try {
+			const registration = supervisor.register(
+				join(dir, "child.jsonl"),
+				"child",
+			);
+			await registration.wait(new AbortController().signal);
+			assert.equal((await registration.inspectPane()).kind, "present");
+			assert.equal(fallbackInspections, 1);
+			registration.unregister();
+		} finally {
+			supervisor.close();
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
 	it("batches pane reconciliation and refuses malformed-list absence", async () => {
 		let lists = 0;
 		let fallbackInspections = 0;
@@ -4259,6 +4327,21 @@ describe("lifecycle.ts", () => {
 			3_000,
 		);
 		assert.equal(projectLifecycle(lifecycle, 120_000).kind, "active");
+	});
+
+	it("uses activity as a fallback after a status-unknown pane snapshot", () => {
+		let lifecycle = createLifecycle(1_000);
+		lifecycle = observePaneInspection(
+			lifecycle,
+			{ kind: "present", observedAt: 2_000, agentStatus: "unknown" },
+			2_000,
+		);
+		lifecycle = observeLifecycleActivity(
+			lifecycle,
+			{ ok: true, activity: activity() },
+			2_000,
+		);
+		assert.equal(projectLifecycle(lifecycle, 3_000).kind, "active");
 	});
 
 	it("uses activity only as detail and does not override herdr waiting", () => {

--- a/test/test.ts
+++ b/test/test.ts
@@ -2172,6 +2172,57 @@ describe("supervision", () => {
 			}
 		}
 	});
+
+	it("keeps a queued reconciliation when a wake arrives before the next wait", async () => {
+		let listener:
+			| ((event: string, filename: string | Buffer | null) => void)
+			| undefined;
+		const watcher = {
+			on() {
+				return this;
+			},
+			close() {},
+			unref() {
+				return this;
+			},
+		};
+		// SAFETY: The fake implements the fs.watch behavior used by FileWakeRegistry.
+		const registry = new FileWakeRegistry(((
+			_directory: string,
+			callback: (event: string, filename: string | Buffer | null) => void,
+		) => {
+			listener = callback;
+			return watcher;
+		}) as any);
+		const supervisor = new SupervisionCoordinator(
+			async () => ({
+				complete: true,
+				panes: [{ paneId: "one", workspaceId: "workspace" }],
+			}),
+			async () => ({
+				kind: "present",
+				agentStatus: "idle",
+				observedAt: Date.now(),
+			}),
+			false,
+			registry,
+		);
+		try {
+			const registration = supervisor.register("/tmp/child.jsonl", "one");
+			// Let the registration-triggered reconciliation settle and queue its
+			// pending "reconcile" reason before any waiter exists.
+			await new Promise((resolve) => setImmediate(resolve));
+			await new Promise((resolve) => setImmediate(resolve));
+			listener?.("rename", null);
+			assert.equal(
+				await registration.wait(new AbortController().signal),
+				"reconcile",
+			);
+			registration.unregister();
+		} finally {
+			supervisor.close();
+		}
+	});
 });
 
 describe("role configuration", () => {

--- a/test/test.ts
+++ b/test/test.ts
@@ -4343,6 +4343,43 @@ describe("completion.ts", () => {
 		}
 	});
 
+	it("prefers semantic sidecars published during a zero-exit terminal read", async () => {
+		for (const [payload, expected] of [
+			[
+				{ type: "ping", name: "Scout", message: "need input" },
+				{
+					reason: "ping",
+					exitCode: 0,
+					ping: { name: "Scout", message: "need input" },
+				},
+			],
+			[
+				{ type: "error", errorMessage: "late semantic failure" },
+				{
+					reason: "error",
+					exitCode: 1,
+					errorMessage: "late semantic failure",
+				},
+			],
+		] as const) {
+			const dir = mkdtempSync(join(tmpdir(), "completion-zero-race-"));
+			const sessionFile = join(dir, "child.jsonl");
+			try {
+				const result = await waitForCompletion(new AbortController().signal, {
+					intervalMs: 1,
+					sessionFile,
+					readTerminalTail: async () => {
+						writeFileSync(`${sessionFile}.exit`, JSON.stringify(payload));
+						return "__SUBAGENT_DONE_0__";
+					},
+				});
+				assert.deepEqual(result, expected);
+			} finally {
+				rmSync(dir, { recursive: true, force: true });
+			}
+		}
+	});
+
 	it("retries transient terminal read failures and reports ticks", async () => {
 		let reads = 0;
 		let ticks = 0;

--- a/test/test.ts
+++ b/test/test.ts
@@ -84,7 +84,10 @@ import {
 	parseSupervisionConfig,
 } from "../pi-extension/subagents/supervision-config.ts";
 import { FileWakeRegistry } from "../pi-extension/subagents/wake.ts";
-import { SupervisionCoordinator } from "../pi-extension/subagents/supervision.ts";
+import {
+	POLLING_INTERVAL_MS,
+	SupervisionCoordinator,
+} from "../pi-extension/subagents/supervision.ts";
 import {
 	advanceStatusState,
 	capStatusLines,
@@ -1936,6 +1939,41 @@ describe("supervision", () => {
 		});
 	});
 
+	it("wakes every directory entry when fs.watch omits a filename", () => {
+		let listener:
+			| ((event: string, filename: string | Buffer | null) => void)
+			| undefined;
+		const watcher = {
+			on() {
+				return this;
+			},
+			close() {},
+			unref() {
+				return this;
+			},
+		};
+		// SAFETY: The fake implements the fs.watch behavior used by FileWakeRegistry.
+		const registry = new FileWakeRegistry(((
+			_directory: string,
+			callback: (event: string, filename: string | Buffer | null) => void,
+		) => {
+			listener = callback;
+			return watcher;
+		}) as any);
+		let wakes = 0;
+		const registration = registry.register(
+			"/tmp/child.jsonl",
+			() => {
+				wakes += 1;
+			},
+			() => assert.fail("watcher unexpectedly fell back"),
+		);
+		listener?.("change", null);
+		assert.equal(wakes, 1);
+		registration.unregister();
+		registry.close();
+	});
+
 	it("wakes on sidecar rename and releases registrations", async () => {
 		const dir = createTestDir();
 		const sessionFile = join(dir, "child.jsonl");
@@ -1952,7 +1990,9 @@ describe("supervision", () => {
 			const temporary = `${sessionFile}.exit.tmp`;
 			writeFileSync(temporary, "{}");
 			renameSync(temporary, `${sessionFile}.exit`);
-			await new Promise((resolve) => setTimeout(resolve, 50));
+			const deadline = Date.now() + 500;
+			while (wakes === 0 && Date.now() < deadline)
+				await new Promise((resolve) => setTimeout(resolve, 10));
 			assert.equal(wakes, 1);
 			registration.unregister();
 			assert.equal(registry.watcherCount, 0);
@@ -2030,49 +2070,106 @@ describe("supervision", () => {
 		}
 	});
 
-	it("batches pane reconciliation and refuses malformed-list absence", async () => {
-		let lists = 0;
+	it("keeps watcherless entries on the legacy polling cadence", async () => {
 		let fallbackInspections = 0;
+		// SAFETY: This fake fs.watch always throws to model an unavailable watcher.
+		const registry = new FileWakeRegistry((() => {
+			throw new Error("watch unavailable");
+		}) as any);
 		const supervisor = new SupervisionCoordinator(
-			async () => {
-				lists += 1;
-				return {
-					complete: true,
-					panes: [
-						{
-							paneId: "one",
-							workspaceId: "workspace",
-							inspection: { kind: "present", observedAt: Date.now() } as const,
-						},
-						{
-							paneId: "two",
-							workspaceId: "workspace",
-							inspection: { kind: "present", observedAt: Date.now() } as const,
-						},
-					],
-				};
-			},
+			async () => ({
+				complete: true,
+				panes: [{ paneId: "child", workspaceId: "workspace" }],
+			}),
 			async () => {
 				fallbackInspections += 1;
-				return { kind: "unavailable", error: "fallback" };
+				return { kind: "present", agentStatus: "idle", observedAt: Date.now() };
 			},
+			false,
+			registry,
 		);
 		const dir = createTestDir();
 		try {
-			const one = supervisor.register(join(dir, "one.jsonl"), "one");
-			const two = supervisor.register(join(dir, "two.jsonl"), "two");
-			await Promise.all([
-				one.wait(new AbortController().signal),
-				two.wait(new AbortController().signal),
-			]);
-			assert.equal(lists, 1);
-			assert.equal((await one.inspectPane()).kind, "present");
-			assert.equal(fallbackInspections, 0);
-			one.unregister();
-			two.unregister();
+			const registration = supervisor.register(
+				join(dir, "child.jsonl"),
+				"child",
+			);
+			await registration.wait(new AbortController().signal);
+			assert.equal(supervisor.diagnostics().mode, "polling(fallback)");
+			assert.equal((await registration.inspectPane()).kind, "present");
+			await new Promise((resolve) => setImmediate(resolve));
+			await registration.wait(new AbortController().signal);
+			assert.equal((await registration.inspectPane()).kind, "present");
+			const startedAt = Date.now();
+			await registration.wait(new AbortController().signal);
+			assert.ok(Date.now() - startedAt >= POLLING_INTERVAL_MS - 100);
+			assert.equal((await registration.inspectPane()).kind, "present");
+			assert.equal(fallbackInspections, 3);
+			registration.unregister();
 		} finally {
 			supervisor.close();
 			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("clears the unhealthy batch retry when closed", async () => {
+		const timeouts: Array<() => void> = [];
+		const cleared: Array<() => void> = [];
+		const timers = {
+			setTimeout(callback: () => void) {
+				timeouts.push(callback);
+				// SAFETY: clearTimeout receives this opaque token only in this test.
+				return callback as any;
+			},
+			clearTimeout(timer: () => void) {
+				cleared.push(timer);
+			},
+		};
+		const supervisor = new SupervisionCoordinator(
+			async () => {
+				throw new Error("pane list unavailable");
+			},
+			async () => ({ kind: "unavailable" }),
+			false,
+			new FileWakeRegistry(),
+			timers,
+		);
+		const registration = supervisor.register("/tmp/child.jsonl", "child");
+		await new Promise((resolve) => setImmediate(resolve));
+		supervisor.close();
+		assert.equal(timeouts.length, 1);
+		assert.deepEqual(cleared, timeouts);
+		registration.unregister();
+	});
+
+	it("refuses malformed-list absence", async () => {
+		for (const snapshot of [
+			{ complete: false, panes: [] },
+			{ complete: false, panes: [{ paneId: "one", workspaceId: "workspace" }] },
+		]) {
+			let fallbackInspections = 0;
+			const supervisor = new SupervisionCoordinator(
+				async () => snapshot,
+				async () => {
+					fallbackInspections += 1;
+					return {
+						kind: "present",
+						agentStatus: "idle",
+						observedAt: Date.now(),
+					};
+				},
+			);
+			const dir = createTestDir();
+			try {
+				const registration = supervisor.register(join(dir, "one.jsonl"), "one");
+				await registration.wait(new AbortController().signal);
+				assert.equal((await registration.inspectPane()).kind, "present");
+				assert.equal(fallbackInspections, 1);
+				registration.unregister();
+			} finally {
+				supervisor.close();
+				rmSync(dir, { recursive: true, force: true });
+			}
 		}
 	});
 });
@@ -7524,6 +7621,31 @@ describe("herdr.ts", () => {
 						isLinkedWorktree: true,
 					},
 				],
+			);
+		});
+
+		it("accepts only complete, unique pane snapshots", () => {
+			const snapshot = (
+				panes: Array<{ pane_id?: string; workspace_id?: string } | null>,
+			) => JSON.stringify({ result: { type: "pane_list", panes } });
+			assert.deepEqual(__herdrTest__.parseHerdrPaneSnapshot(snapshot([])), []);
+			assert.equal(__herdrTest__.parseHerdrPaneSnapshot('{"result":{}}'), null);
+			assert.equal(
+				__herdrTest__.parseHerdrPaneSnapshot(
+					snapshot([
+						{ pane_id: "p1", workspace_id: "w1" },
+						{ pane_id: "p1", workspace_id: "w1" },
+					]),
+				),
+				null,
+			);
+			assert.equal(
+				__herdrTest__.parseHerdrPaneSnapshot(snapshot([{ pane_id: "p1" }])),
+				null,
+			);
+			assert.equal(
+				__herdrTest__.parseHerdrPaneSnapshot(snapshot([null, {}])),
+				null,
 			);
 		});
 

--- a/test/test.ts
+++ b/test/test.ts
@@ -80,6 +80,12 @@ import {
 	parsePersistentConfig,
 } from "../pi-extension/subagents/persistent-config.ts";
 import {
+	loadSupervisionConfig,
+	parseSupervisionConfig,
+} from "../pi-extension/subagents/supervision-config.ts";
+import { FileWakeRegistry } from "../pi-extension/subagents/wake.ts";
+import { SupervisionCoordinator } from "../pi-extension/subagents/supervision.ts";
+import {
 	advanceStatusState,
 	capStatusLines,
 	classifyStatus,
@@ -1903,6 +1909,103 @@ describe("persistent specialist configuration", () => {
 				{ maxAgents: 2 },
 			);
 		});
+	});
+});
+
+describe("supervision", () => {
+	it("parses forcePolling strictly and loads the shared example", () => {
+		assert.deepEqual(parseSupervisionConfig({}), { forcePolling: false });
+		assert.deepEqual(
+			parseSupervisionConfig({ supervision: { forcePolling: true } }),
+			{ forcePolling: true },
+		);
+		assert.throws(
+			() => parseSupervisionConfig({ supervision: { extra: true } }),
+			/supervision has unsupported key\(s\): extra/,
+		);
+		withTempDir((dir) => {
+			const example = join(dir, "config.json.example");
+			writeFileSync(
+				example,
+				JSON.stringify({ supervision: { forcePolling: true } }),
+			);
+			assert.deepEqual(
+				loadSupervisionConfig(join(dir, "config.json"), example),
+				{ forcePolling: true },
+			);
+		});
+	});
+
+	it("wakes on sidecar rename and releases registrations", async () => {
+		const dir = createTestDir();
+		const sessionFile = join(dir, "child.jsonl");
+		let wakes = 0;
+		const registry = new FileWakeRegistry();
+		const registration = registry.register(
+			sessionFile,
+			() => {
+				wakes += 1;
+			},
+			() => assert.fail("watcher unexpectedly fell back"),
+		);
+		try {
+			const temporary = `${sessionFile}.exit.tmp`;
+			writeFileSync(temporary, "{}");
+			renameSync(temporary, `${sessionFile}.exit`);
+			await new Promise((resolve) => setTimeout(resolve, 50));
+			assert.equal(wakes, 1);
+			registration.unregister();
+			assert.equal(registry.watcherCount, 0);
+		} finally {
+			registry.close();
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("batches pane reconciliation and refuses malformed-list absence", async () => {
+		let lists = 0;
+		let fallbackInspections = 0;
+		const supervisor = new SupervisionCoordinator(
+			async () => {
+				lists += 1;
+				return {
+					complete: true,
+					panes: [
+						{
+							paneId: "one",
+							workspaceId: "workspace",
+							inspection: { kind: "present", observedAt: Date.now() } as const,
+						},
+						{
+							paneId: "two",
+							workspaceId: "workspace",
+							inspection: { kind: "present", observedAt: Date.now() } as const,
+						},
+					],
+				};
+			},
+			async () => {
+				fallbackInspections += 1;
+				return { kind: "unavailable", error: "fallback" };
+			},
+		);
+		const dir = createTestDir();
+		try {
+			const one = supervisor.register(join(dir, "one.jsonl"), "one");
+			const two = supervisor.register(join(dir, "two.jsonl"), "two");
+			await Promise.all([
+				one.wait(new AbortController().signal),
+				two.wait(new AbortController().signal),
+			]);
+			assert.equal(lists, 1);
+			assert.equal((await one.inspectPane()).kind, "present");
+			assert.equal(fallbackInspections, 0);
+			one.unregister();
+			two.unregister();
+		} finally {
+			supervisor.close();
+			rmSync(dir, { recursive: true, force: true });
+		}
 	});
 });
 


### PR DESCRIPTION
Closes #29.

## What

Replaces the per-child 1-second Herdr CLI poll (`pane read` + `pane get` per pending child, plus a second 1s `.tasks` poller per persistent specialist) with event-driven supervision:

- **File wake-ups**: shared `fs.watch` directory watchers on session-adjacent `.exit`/`.tasks` evidence files; coalescing signals that only prompt evidence collection — never establish outcomes.
- **Batched reconciliation**: one runtime-owned 4.8s epoch shares a single `pane list` snapshot across all pending children. Snapshots are scoped to the entries registered when the list started; absence always requires a per-pane `pane get` confirmation (a well-formed, empty, or in-flight-stale list can never fail a live child).
- **Quiet fallback**: watcherless or degraded transport automatically restores the legacy 1s cadence; `supervision.forcePolling` config forces it diagnostically. Transport transitions never cause a parent model turn; mode is visible in `subagents_list`.
- **Evidence-race fix** (standalone correctness bug on main): a `.exit` sidecar published during an async pane read was stranded by an immediately-accepted exit-0 sentinel; every terminal observation now rechecks semantic evidence first, including `.tasks` for persistent children.
- Reload-safe ownership in the runtime registry; all handles unref'd and closed on shutdown.

## Measured (test/bench/supervision-bench.mjs)

Isolated Herdr server, deterministic held panes, 20s steady-state windows, 3 rotated rounds at 10 children (method and limits documented in the README — this measures the supervision seams, not parent-model delivery):

| Children | Baseline CLI/s | Wake+batch CLI/s | Reduction | CPU ms/s | Detection latency | Max gap |
|---:|---:|---:|---:|---|---|---:|
| 1 | 1.60 | 0.40 | 75.0% | 180→30 | 463.7→4.1ms | 4.81s |
| 5 | 7.20 | 1.20 | 83.3% | 650→100 | 380.4→3.5ms | 4.81s |
| 10 | 14.20 | 2.20 | **84.5%** | 1190→180 | 449.0→3.2ms | 4.82s |

All agreed gates pass: ≥80% reduction at 10 children, no CPU or delivery-latency regression, reconciliation gap <5s.

## Field evidence for this ticket's premise

During this very implementation, two child agents froze mid-provider-tool-call (5h and 66min idle-in-turn) and the existing stall supervision never escalated either to the parent — recovered only by manual inspection. Idle-in-turn hang detection is worth a follow-up once this lands.

## Review

Cross-family (Claude Opus 4.8 spec, Grok 4.6 standards/concurrency): both initially NEEDS CHANGES — P0 in-flight-snapshot absence race, fabricated present inspections, watcherless polling loss, leaked unhealthy timer (the likely cause of a sporadic tests-pass-exit-nonzero) — all fixed test-first; both re-reviews APPROVE with no merge blockers. Disclosed residuals: benchmark uses held panes rather than persistent Pi workloads; two integration assertions could be stronger.

## Verification

Unit 319/319 (×2 runs, clean exits); format, lint, `npm pack --dry-run` (bench excluded), `git diff --check`; no new strict-mode TypeScript errors vs base; deterministic Herdr suite 33/33 including five new supervision fault scenarios; no leaked test resources. No version bump.
