### PR TITLE
feat: no-progress advisories for active subagents (#40)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -18,6 +18,12 @@ The parent-facing handoff of a child run's observed outcome and available
 evidence. Receiving it does not establish that the work is correct or accepted.
 _Avoid_: Wake-up signal, acceptance
 
+**No-progress advisory**:
+An internal warning that an active child shows no durable progress in its session
+JSONL or activity snapshot. It is advisory only and never changes the child's
+outcome or triggers recovery.
+_Avoid_: Hang verdict, automatic recovery, stall replacement
+
 **Legacy external CLI role**:
 An old role definition that contains `cli`. Discovery reports a migration
 diagnostic, and launch fails before Herdr creates a pane or worktree. Remove

--- a/README.md
+++ b/README.md
@@ -301,7 +301,8 @@ cp config.json.example config.json
     "maxAgents": 3
   },
   "supervision": {
-    "forcePolling": false
+    "forcePolling": false,
+    "hangWarningMinutes": 15
   },
   "panes": {
     "mode": "tab",
@@ -347,6 +348,29 @@ disable wake-ups and use that legacy cadence deliberately. The setting is read
 when the coordinator is created, so run `/reload` after changing it.
 `subagents_list` reports the active transport mode (`wake+batch`,
 `polling(forced)`, or `polling(fallback)`) and watcher count.
+
+`supervision.hangWarningMinutes` defaults to `15`; set it to `0` to disable
+no-progress advisories. For example, this keeps the default transport and sets
+a 30-minute advisory budget:
+
+```json
+{
+  "supervision": {
+    "forcePolling": false,
+    "hangWarningMinutes": 30
+  }
+}
+```
+
+While a child projects active or blocked, the parent compares durable session
+JSONL and activity-snapshot updates against this budget. An advisory is warning-only, fires once per no-progress episode, and
+never interrupts, kills, retries, or restarts a child. It identifies either a
+`blocked-tool` (an outstanding tool call may still complete) or a
+`truncated-turn` (a `toolUse` turn without a tool call cannot self-heal), then
+includes the session path and manual recovery options. Interactive children stay
+quiet just as they do for stalled/recovered notices; their widget state still
+updates. A later durable update clears the episode and sends the corresponding
+recovered notice for non-interactive children.
 `polling(fallback)` means at least one tracked child is using per-child polling;
 other children can still use wake+batch.
 

--- a/README.md
+++ b/README.md
@@ -365,9 +365,14 @@ a 30-minute advisory budget:
 While a child projects active or blocked, the parent compares durable session
 JSONL and activity-snapshot updates against this budget. An advisory is warning-only, fires once per no-progress episode, and
 never interrupts, kills, retries, or restarts a child. It identifies `blocked-tool` (an outstanding tool call may still complete),
-`truncated-turn` (a `toolUse` turn without a tool call cannot self-heal), or
+`truncated-turn` (an observed `toolUse` stop with no tool call; its cause is unknown), or
 `generic-no-progress` when neither condition is established, then
-includes the session path and manual recovery options. Interactive children stay
+includes the session path and manual recovery options. Ordinary children can be
+interrupted or, after manual termination, resumed or newly spawned. Persistent
+ordinary-pane specialists can be interrupted or stopped with `subagent_stop` and
+replaced; they cannot be resumed. Managed-worktree children, including persistent
+ones, retain their workspace and continue there only after the previous process
+has exited; do not use `subagent_resume` or start a concurrent writer. Interactive children stay
 quiet just as they do for stalled/recovered notices; their widget state still
 updates. A later durable update clears the episode and sends the corresponding
 recovered notice for non-interactive children.

--- a/README.md
+++ b/README.md
@@ -364,9 +364,9 @@ a 30-minute advisory budget:
 
 While a child projects active or blocked, the parent compares durable session
 JSONL and activity-snapshot updates against this budget. An advisory is warning-only, fires once per no-progress episode, and
-never interrupts, kills, retries, or restarts a child. It identifies either a
-`blocked-tool` (an outstanding tool call may still complete) or a
-`truncated-turn` (a `toolUse` turn without a tool call cannot self-heal), then
+never interrupts, kills, retries, or restarts a child. It identifies `blocked-tool` (an outstanding tool call may still complete),
+`truncated-turn` (a `toolUse` turn without a tool call cannot self-heal), or
+`generic-no-progress` when neither condition is established, then
 includes the session path and manual recovery options. Interactive children stay
 quiet just as they do for stalled/recovered notices; their widget state still
 updates. A later durable update clears the episode and sends the corresponding

--- a/config.json.example
+++ b/config.json.example
@@ -12,7 +12,8 @@
     "maxAgents": 3
   },
   "supervision": {
-    "forcePolling": false
+    "forcePolling": false,
+    "hangWarningMinutes": 15
   },
   "panes": {
     "mode": "tab",

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -62,6 +62,9 @@ import {
 	appendPersistentDeliveryLedger,
 	findLastAssistantMessage,
 	findObservedSessionRuntime,
+	inspectNoProgressSessionTail,
+	type NoProgressClassification,
+	type NoProgressSessionTail,
 	getNewEntries,
 	createBtwSessionSnapshot,
 	readPersistentDeliveryLedger,
@@ -1348,6 +1351,13 @@ interface RunningSubagent {
 	lifecycle: SubagentLifecycle;
 	/** Last projected kind used to detect stalled/recovered transitions. */
 	lastProjectedKind?: LifecycleProjection["kind"];
+	/** One active no-progress warning episode, reset when durable progress resumes. */
+	noProgressEpisode?: {
+		active: true;
+		idleMs: number;
+		classification: NoProgressClassification;
+		lastEntryKind: NoProgressSessionTail["lastEntryKind"];
+	};
 	/**
 	 * When true, status transitions (stalled/recovered) do not wake the parent
 	 * session via a steer message. The widget still updates locally. Used for
@@ -1744,6 +1754,107 @@ function observeRunningSubagent(
 		read,
 		observedAt,
 	);
+}
+
+type NoProgressAdvisoryEvent =
+	| {
+			kind: "warning";
+			idleMs: number;
+			classification: NoProgressClassification;
+			lastEntryKind: NoProgressSessionTail["lastEntryKind"];
+			notify: boolean;
+	  }
+	| {
+			kind: "recovered";
+			idleMs: number;
+			classification: NoProgressClassification;
+			lastEntryKind: NoProgressSessionTail["lastEntryKind"];
+			notify: boolean;
+	  };
+
+function evaluateNoProgressAdvisory(
+	running: RunningSubagent,
+	projection: LifecycleProjection,
+	now: number,
+	hangWarningMinutes: number,
+): NoProgressAdvisoryEvent | undefined {
+	if (hangWarningMinutes === 0) {
+		delete running.noProgressEpisode;
+		return;
+	}
+	if (projection.kind !== "active" && projection.kind !== "blocked") {
+		delete running.noProgressEpisode;
+		return;
+	}
+
+	let sessionMtime: number;
+	try {
+		sessionMtime = statSync(running.sessionFile).mtimeMs;
+	} catch {
+		// Session evidence is unavailable; do not turn that I/O problem into a hang.
+		return;
+	}
+	const progressAt = Math.min(
+		now,
+		Math.max(
+			sessionMtime,
+			running.activity?.updatedAt ?? Number.NEGATIVE_INFINITY,
+		),
+	);
+	const idleMs = Math.max(0, now - progressAt);
+	if (idleMs <= hangWarningMinutes * 60_000) {
+		const previous = running.noProgressEpisode;
+		delete running.noProgressEpisode;
+		return previous
+			? {
+					kind: "recovered",
+					idleMs: previous.idleMs,
+					classification: previous.classification,
+					lastEntryKind: previous.lastEntryKind,
+					notify: !running.interactive,
+				}
+			: undefined;
+	}
+	if (running.noProgressEpisode) return;
+
+	let tail: NoProgressSessionTail = {
+		classification: "generic-no-progress",
+		lastEntryKind: "other",
+	};
+	try {
+		// The bounded reader is deliberately cold-path only: mtime/snapshot checks
+		// above run on every refresh, but JSONL parsing happens once per episode.
+		tail = inspectNoProgressSessionTail(running.sessionFile);
+	} catch {
+		// A session can disappear between stat and read; preserve a facts-only
+		// generic advisory rather than failing the status loop.
+	}
+	running.noProgressEpisode = { active: true, idleMs, ...tail };
+	return { kind: "warning", idleMs, ...tail, notify: !running.interactive };
+}
+
+function formatNoProgressAdvisoryLine(
+	running: RunningSubagent,
+	event: NoProgressAdvisoryEvent,
+): string {
+	const name = normalizeStatusName(running.name);
+	const persistentIds = running.persistent
+		? ` Logical ID: ${running.logicalId ?? "unknown"}; generation ID: ${running.generationId ?? "unknown"}.`
+		: "";
+	if (event.kind === "recovered") {
+		return `${name} no-progress advisory recovered after ${formatElapsedDuration(event.idleMs)}.${persistentIds}`;
+	}
+	const classification =
+		event.classification === "blocked-tool"
+			? "blocked-tool; the outstanding tool may still complete"
+			: event.classification === "truncated-turn"
+				? "truncated-turn; the recorded turn cannot self-heal"
+				: "generic no-progress";
+	const options =
+		event.classification === "truncated-turn"
+			? "kill + subagent_resume or kill + new spawn"
+			: "interrupt, kill + subagent_resume, or kill + new spawn";
+	return `${name} no-progress advisory: ${formatElapsedDuration(event.idleMs)} idle while active. Classification: ${classification}. Last entry: ${event.lastEntryKind}. Session: ${running.sessionFile}. Recovery options: ${options}.${persistentIds}`;
 }
 
 function resolveInterruptTarget(params: {
@@ -2180,6 +2291,16 @@ function startStatusRefresh(pi: ExtensionAPI) {
 					),
 				);
 			}
+
+			const noProgress = evaluateNoProgressAdvisory(
+				running,
+				projection,
+				now,
+				supervisionConfig.hangWarningMinutes,
+			);
+			if (noProgress?.notify) {
+				transitionLines.push(formatNoProgressAdvisoryLine(running, noProgress));
+			}
 		}
 
 		if (shouldRefreshWidget) updateWidget();
@@ -2244,6 +2365,8 @@ export const __test__ = {
 	buildBtwLaunchCommand,
 	resolveEffectivePersistent,
 	observeRunningSubagent,
+	evaluateNoProgressAdvisory,
+	formatNoProgressAdvisoryLine,
 	resolveDenyTools,
 	resolveInterruptTarget,
 	requestSubagentInterrupt,

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -1354,6 +1354,7 @@ interface RunningSubagent {
 	/** One active no-progress warning episode, reset when durable progress resumes. */
 	noProgressEpisode?: {
 		active: true;
+		progressAt: number;
 		idleMs: number;
 		classification: NoProgressClassification;
 		lastEntryKind: NoProgressSessionTail["lastEntryKind"];
@@ -1808,7 +1809,7 @@ function evaluateNoProgressAdvisory(
 		return previous
 			? {
 					kind: "recovered",
-					idleMs: previous.idleMs,
+					idleMs: Math.max(0, now - previous.progressAt),
 					classification: previous.classification,
 					lastEntryKind: previous.lastEntryKind,
 					notify: !running.interactive,
@@ -1829,7 +1830,7 @@ function evaluateNoProgressAdvisory(
 		// A session can disappear between stat and read; preserve a facts-only
 		// generic advisory rather than failing the status loop.
 	}
-	running.noProgressEpisode = { active: true, idleMs, ...tail };
+	running.noProgressEpisode = { active: true, progressAt, idleMs, ...tail };
 	return { kind: "warning", idleMs, ...tail, notify: !running.interactive };
 }
 

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -1849,12 +1849,13 @@ function formatNoProgressAdvisoryLine(
 		event.classification === "blocked-tool"
 			? "blocked-tool; the outstanding tool may still complete"
 			: event.classification === "truncated-turn"
-				? "truncated-turn; the recorded turn cannot self-heal"
+				? "truncated-turn; observed toolUse stop with no tool call; cause unknown"
 				: "generic no-progress";
-	const options =
-		event.classification === "truncated-turn"
-			? "kill + subagent_resume or kill + new spawn"
-			: "interrupt, kill + subagent_resume, or kill + new spawn";
+	const options = running.worktree
+		? "interrupt, or retain the workspace and continue there after confirming the previous process exited"
+		: running.persistent
+			? "interrupt, or use subagent_stop then replace with a new persistent specialist"
+			: "interrupt, or after manual termination use subagent_resume or a new spawn";
 	return `${name} no-progress advisory: ${formatElapsedDuration(event.idleMs)} idle while active. Classification: ${classification}. Last entry: ${event.lastEntryKind}. Session: ${running.sessionFile}. Recovery options: ${options}.${persistentIds}`;
 }
 

--- a/pi-extension/subagents/session.ts
+++ b/pi-extension/subagents/session.ts
@@ -1,10 +1,14 @@
 import { SessionManager } from "@earendil-works/pi-coding-agent";
 import {
 	appendFileSync,
+	closeSync,
 	copyFileSync,
 	existsSync,
+	fstatSync,
 	mkdirSync,
+	openSync,
 	readFileSync,
+	readSync,
 	readdirSync,
 	renameSync,
 	rmSync,
@@ -692,6 +696,89 @@ function readEntries(sessionFile: string): SessionEntry[] {
 		.split("\n")
 		.filter((line) => line.trim())
 		.map(parseEntry);
+}
+
+export type NoProgressClassification =
+	| "blocked-tool"
+	| "truncated-turn"
+	| "generic-no-progress";
+
+export interface NoProgressSessionTail {
+	classification: NoProgressClassification;
+	lastEntryKind: "assistant" | "tool-result" | "message" | "other" | "none";
+}
+
+const NO_PROGRESS_TAIL_BYTES = 128 * 1024;
+
+/**
+ * Read only the final portion of a session when a no-progress warning is due.
+ * Torn or malformed JSONL lines are ignored because Pi can be writing the tail.
+ */
+export function inspectNoProgressSessionTail(
+	sessionFile: string,
+): NoProgressSessionTail {
+	const fd = openSync(sessionFile, "r");
+	let raw: string;
+	let truncated = false;
+	try {
+		const size = fstatSync(fd).size;
+		const start = Math.max(0, size - NO_PROGRESS_TAIL_BYTES);
+		truncated = start > 0;
+		const buffer = Buffer.alloc(size - start);
+		readSync(fd, buffer, 0, buffer.length, start);
+		raw = buffer.toString("utf8");
+	} finally {
+		closeSync(fd);
+	}
+
+	const lines = raw.split("\n");
+	if (truncated) lines.shift();
+	const entries = lines.flatMap((line) => {
+		if (!line.trim()) return [];
+		try {
+			const value: unknown = JSON.parse(line);
+			return isRecord(value) ? [value] : [];
+		} catch {
+			return [];
+		}
+	});
+	const last = entries.at(-1);
+	const lastEntryKind: NoProgressSessionTail["lastEntryKind"] = !last
+		? "none"
+		: last.type === "message" && isRecord(last.message)
+			? last.message.role === "assistant"
+				? "assistant"
+				: last.message.role === "toolResult"
+					? "tool-result"
+					: "message"
+			: "other";
+
+	for (let index = entries.length - 1; index >= 0; index--) {
+		const entry = entries[index];
+		if (entry.type !== "message" || !isRecord(entry.message)) continue;
+		if (entry.message.role !== "assistant") continue;
+		const content = entry.message.content;
+		const hasToolCall =
+			Array.isArray(content) &&
+			content.some((block) => isRecord(block) && block.type === "toolCall");
+		const hasToolResultAfter = entries
+			.slice(index + 1)
+			.some(
+				(entry) =>
+					entry.type === "message" &&
+					isRecord(entry.message) &&
+					entry.message.role === "toolResult",
+			);
+		if (hasToolCall && !hasToolResultAfter) {
+			return { classification: "blocked-tool", lastEntryKind };
+		}
+		if (entry.message.stopReason === "toolUse" && !hasToolCall) {
+			return { classification: "truncated-turn", lastEntryKind };
+		}
+		break;
+	}
+
+	return { classification: "generic-no-progress", lastEntryKind };
 }
 
 /**

--- a/pi-extension/subagents/session.ts
+++ b/pi-extension/subagents/session.ts
@@ -758,18 +758,32 @@ export function inspectNoProgressSessionTail(
 		if (entry.type !== "message" || !isRecord(entry.message)) continue;
 		if (entry.message.role !== "assistant") continue;
 		const content = entry.message.content;
-		const hasToolCall =
-			Array.isArray(content) &&
-			content.some((block) => isRecord(block) && block.type === "toolCall");
-		const hasToolResultAfter = entries
-			.slice(index + 1)
-			.some(
-				(entry) =>
+		const toolCallIds = new Set(
+			Array.isArray(content)
+				? content.flatMap((block) =>
+						isRecord(block) && block.type === "toolCall" && isString(block.id)
+							? [block.id]
+							: [],
+					)
+				: [],
+		);
+		const resolvedToolCallIds = new Set(
+			entries
+				.slice(index + 1)
+				.flatMap((entry) =>
 					entry.type === "message" &&
 					isRecord(entry.message) &&
-					entry.message.role === "toolResult",
-			);
-		if (hasToolCall && !hasToolResultAfter) {
+					entry.message.role === "toolResult" &&
+					isString(entry.message.toolCallId)
+						? [entry.message.toolCallId]
+						: [],
+				),
+		);
+		const hasToolCall = toolCallIds.size > 0;
+		const hasOutstandingToolCall = [...toolCallIds].some(
+			(toolCallId) => !resolvedToolCallIds.has(toolCallId),
+		);
+		if (hasToolCall && hasOutstandingToolCall) {
 			return { classification: "blocked-tool", lastEntryKind };
 		}
 		if (entry.message.stopReason === "toolUse" && !hasToolCall) {

--- a/pi-extension/subagents/session.ts
+++ b/pi-extension/subagents/session.ts
@@ -719,20 +719,25 @@ export function inspectNoProgressSessionTail(
 ): NoProgressSessionTail {
 	const fd = openSync(sessionFile, "r");
 	let raw: string;
-	let truncated = false;
+	let startsWithinLine = false;
 	try {
 		const size = fstatSync(fd).size;
 		const start = Math.max(0, size - NO_PROGRESS_TAIL_BYTES);
-		truncated = start > 0;
+		if (start > 0) {
+			const preceding = Buffer.alloc(1);
+			startsWithinLine =
+				readSync(fd, preceding, 0, preceding.length, start - 1) !== 1 ||
+				preceding[0] !== 0x0a;
+		}
 		const buffer = Buffer.alloc(size - start);
-		readSync(fd, buffer, 0, buffer.length, start);
-		raw = buffer.toString("utf8");
+		const bytesRead = readSync(fd, buffer, 0, buffer.length, start);
+		raw = buffer.subarray(0, bytesRead).toString("utf8");
 	} finally {
 		closeSync(fd);
 	}
 
 	const lines = raw.split("\n");
-	if (truncated) lines.shift();
+	if (startsWithinLine) lines.shift();
 	const entries = lines.flatMap((line) => {
 		if (!line.trim()) return [];
 		try {

--- a/pi-extension/subagents/supervision-config.ts
+++ b/pi-extension/subagents/supervision-config.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { isBoolean, isRecord } from "./type-guards.ts";
+import { isBoolean, isFiniteNumber, isRecord } from "./type-guards.ts";
 
 const PACKAGE_ROOT = join(dirname(fileURLToPath(import.meta.url)), "../..");
 const DEFAULT_CONFIG_PATH = join(PACKAGE_ROOT, "config.json");
@@ -9,6 +9,7 @@ const EXAMPLE_CONFIG_PATH = join(PACKAGE_ROOT, "config.json.example");
 
 export interface SupervisionConfig {
 	forcePolling: boolean;
+	hangWarningMinutes: number;
 }
 
 function invalid(source: string, message: string): never {
@@ -22,12 +23,14 @@ export function parseSupervisionConfig(
 	source = "config.json",
 ): SupervisionConfig {
 	if (!isRecord(rawConfig)) invalid(source, "root must be an object");
-	if (!Object.hasOwn(rawConfig, "supervision")) return { forcePolling: false };
+	if (!Object.hasOwn(rawConfig, "supervision")) {
+		return { forcePolling: false, hangWarningMinutes: 15 };
+	}
 	if (!isRecord(rawConfig.supervision)) {
 		invalid(source, "supervision must be an object");
 	}
 	const unsupported = Object.keys(rawConfig.supervision).filter(
-		(key) => key !== "forcePolling",
+		(key) => key !== "forcePolling" && key !== "hangWarningMinutes",
 	);
 	if (unsupported.length > 0) {
 		invalid(
@@ -35,13 +38,29 @@ export function parseSupervisionConfig(
 			`supervision has unsupported key(s): ${unsupported.join(", ")}`,
 		);
 	}
-	if (!Object.hasOwn(rawConfig.supervision, "forcePolling")) {
-		return { forcePolling: false };
-	}
-	if (!isBoolean(rawConfig.supervision.forcePolling)) {
+	const forcePolling = Object.hasOwn(rawConfig.supervision, "forcePolling")
+		? rawConfig.supervision.forcePolling
+		: false;
+	if (!isBoolean(forcePolling)) {
 		invalid(source, "supervision.forcePolling must be a boolean");
 	}
-	return { forcePolling: rawConfig.supervision.forcePolling };
+	const hangWarningMinutes = Object.hasOwn(
+		rawConfig.supervision,
+		"hangWarningMinutes",
+	)
+		? rawConfig.supervision.hangWarningMinutes
+		: 15;
+	if (
+		!isFiniteNumber(hangWarningMinutes) ||
+		!Number.isInteger(hangWarningMinutes) ||
+		hangWarningMinutes < 0
+	) {
+		invalid(
+			source,
+			"supervision.hangWarningMinutes must be a non-negative integer",
+		);
+	}
+	return { forcePolling, hangWarningMinutes };
 }
 
 export function loadSupervisionConfig(

--- a/test/integration/hang-advisory.test.ts
+++ b/test/integration/hang-advisory.test.ts
@@ -60,7 +60,7 @@ describe("hang advisory integration", () => {
 			assert.equal(advisory?.notify, true);
 			assert.match(
 				subagentsModule.__test__.formatNoProgressAdvisoryLine(child, advisory!),
-				/Recovery options: interrupt, kill \+ subagent_resume, or kill \+ new spawn/,
+				/Recovery options: interrupt, or after manual termination use subagent_resume or a new spawn/,
 			);
 			assert.equal(
 				subagentsModule.__test__.evaluateNoProgressAdvisory(

--- a/test/integration/hang-advisory.test.ts
+++ b/test/integration/hang-advisory.test.ts
@@ -30,7 +30,8 @@ function activeChild(sessionFile: string, interactive = false) {
 }
 
 describe("hang advisory integration", () => {
-	it("notifies once for a blocked active child, recovers on progress, and stays quiet when interactive", () => {
+	// This drives the evaluator seam directly, rather than startStatusRefresh.
+	it("notifies once for a blocked active child, recovers on progress, and suppresses interactive steers", () => {
 		const root = mkdtempSync(join(tmpdir(), "pi-hang-advisory-integ-"));
 		try {
 			const sessionFile = join(root, "child.jsonl");

--- a/test/integration/hang-advisory.test.ts
+++ b/test/integration/hang-advisory.test.ts
@@ -1,0 +1,99 @@
+/** Deterministic component integration for active-child no-progress advisories. */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import * as subagentsModule from "../../pi-extension/subagents/index.ts";
+import {
+	createLifecycle,
+	observePaneInspection,
+	projectLifecycle,
+} from "../../pi-extension/subagents/lifecycle.ts";
+
+function activeChild(sessionFile: string, interactive = false) {
+	return {
+		id: "child",
+		name: "Worker",
+		task: "",
+		surface: "pane",
+		startTime: 0,
+		sessionFile,
+		interactive,
+		runtimePlan: undefined,
+		lifecycle: observePaneInspection(
+			createLifecycle(0),
+			{ kind: "present", observedAt: 1, agentStatus: "working" },
+			1,
+		),
+	};
+}
+
+describe("hang advisory integration", () => {
+	it("notifies once for a blocked active child, recovers on progress, and stays quiet when interactive", () => {
+		const root = mkdtempSync(join(tmpdir(), "pi-hang-advisory-integ-"));
+		try {
+			const sessionFile = join(root, "child.jsonl");
+			writeFileSync(
+				sessionFile,
+				`${JSON.stringify({
+					type: "message",
+					message: {
+						role: "assistant",
+						content: [{ type: "toolCall", id: "call", name: "bash" }],
+						stopReason: "toolUse",
+					},
+				})}\n`,
+			);
+			utimesSync(sessionFile, 0, 0);
+			const now = 120_000;
+			const child = activeChild(sessionFile);
+			const advisory = subagentsModule.__test__.evaluateNoProgressAdvisory(
+				child,
+				projectLifecycle(child.lifecycle, now),
+				now,
+				1,
+			);
+			assert.equal(advisory?.kind, "warning");
+			assert.equal(advisory?.classification, "blocked-tool");
+			assert.equal(advisory?.notify, true);
+			assert.match(
+				subagentsModule.__test__.formatNoProgressAdvisoryLine(child, advisory!),
+				/Recovery options: interrupt, kill \+ subagent_resume, or kill \+ new spawn/,
+			);
+			assert.equal(
+				subagentsModule.__test__.evaluateNoProgressAdvisory(
+					child,
+					projectLifecycle(child.lifecycle, now + 1_000),
+					now + 1_000,
+					1,
+				),
+				undefined,
+			);
+
+			utimesSync(sessionFile, 0, (now + 2_000) / 1_000);
+			assert.equal(
+				subagentsModule.__test__.evaluateNoProgressAdvisory(
+					child,
+					projectLifecycle(child.lifecycle, now + 2_000),
+					now + 2_000,
+					1,
+				)?.kind,
+				"recovered",
+			);
+
+			utimesSync(sessionFile, 0, 0);
+			const interactive = activeChild(sessionFile, true);
+			const quiet = subagentsModule.__test__.evaluateNoProgressAdvisory(
+				interactive,
+				projectLifecycle(interactive.lifecycle, now),
+				now,
+				1,
+			);
+			assert.equal(quiet?.kind, "warning");
+			assert.equal(quiet?.notify, false);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+});

--- a/test/test.ts
+++ b/test/test.ts
@@ -497,6 +497,61 @@ describe("session.ts", () => {
 			assert.equal(findLastAssistantMessage([msg]), null);
 		});
 
+		it("preserves an assistant record that starts exactly at the bounded tail", () => {
+			withTempDir((dir) => {
+				const session = join(dir, "exact-boundary.jsonl");
+				const assistant = JSON.stringify({
+					type: "message",
+					id: "assistant",
+					message: {
+						role: "assistant",
+						content: [{ type: "toolCall", id: "call-1", name: "bash" }],
+						stopReason: "toolUse",
+					},
+				});
+				const tail = `${assistant}\n${"x".repeat(
+					128 * 1024 - Buffer.byteLength(assistant) - 1,
+				)}`;
+				writeFileSync(session, `{"type":"session"}\n${tail}`);
+
+				assert.deepEqual(inspectNoProgressSessionTail(session), {
+					classification: "blocked-tool",
+					lastEntryKind: "assistant",
+				});
+			});
+		});
+
+		it("skips a mid-record cut before a multibyte character", () => {
+			withTempDir((dir) => {
+				const session = join(dir, "mid-record-boundary.jsonl");
+				const assistant = JSON.stringify({
+					type: "message",
+					id: "assistant",
+					message: {
+						role: "assistant",
+						content: [{ type: "toolCall", id: "call-1", name: "bash" }],
+						stopReason: "toolUse",
+					},
+				});
+				const beforeBoundary = Buffer.from(`partial-${"é"}`);
+				const afterBoundary = Buffer.from(`\n${assistant}\n`);
+				const tail = Buffer.concat([
+					beforeBoundary.subarray(-1),
+					afterBoundary,
+					Buffer.alloc(128 * 1024 - 1 - afterBoundary.length, "x"),
+				]);
+				writeFileSync(
+					session,
+					Buffer.concat([beforeBoundary.subarray(0, -1), tail]),
+				);
+
+				assert.deepEqual(inspectNoProgressSessionTail(session), {
+					classification: "blocked-tool",
+					lastEntryKind: "assistant",
+				});
+			});
+		});
+
 		it("classifies bounded JSONL tails without trusting malformed trailing lines", () => {
 			withTempDir((dir) => {
 				const session = join(dir, "hang.jsonl");

--- a/test/test.ts
+++ b/test/test.ts
@@ -530,7 +530,66 @@ describe("session.ts", () => {
 					{
 						type: "message",
 						id: "result",
-						message: { role: "toolResult", content: [] },
+						message: {
+							role: "toolResult",
+							toolCallId: "call-1",
+							content: [],
+						},
+					},
+				]);
+				assert.deepEqual(inspectNoProgressSessionTail(session), {
+					classification: "generic-no-progress",
+					lastEntryKind: "tool-result",
+				});
+
+				writeTail([
+					assistant(
+						[
+							{ type: "toolCall", id: "call-1", name: "bash" },
+							{ type: "toolCall", id: "call-2", name: "read" },
+						],
+						"toolUse",
+					),
+					{
+						type: "message",
+						id: "result-1",
+						message: {
+							role: "toolResult",
+							toolCallId: "call-1",
+							content: [],
+						},
+					},
+				]);
+				assert.deepEqual(inspectNoProgressSessionTail(session), {
+					classification: "blocked-tool",
+					lastEntryKind: "tool-result",
+				});
+
+				writeTail([
+					assistant(
+						[
+							{ type: "toolCall", id: "call-1", name: "bash" },
+							{ type: "toolCall", id: "call-2", name: "read" },
+						],
+						"toolUse",
+					),
+					{
+						type: "message",
+						id: "result-1",
+						message: {
+							role: "toolResult",
+							toolCallId: "call-1",
+							content: [],
+						},
+					},
+					{
+						type: "message",
+						id: "result-2",
+						message: {
+							role: "toolResult",
+							toolCallId: "call-2",
+							content: [],
+						},
 					},
 				]);
 				assert.deepEqual(inspectNoProgressSessionTail(session), {
@@ -4696,19 +4755,21 @@ describe("no-progress advisories", () => {
 				undefined,
 			);
 
-			utimesSync(sessionFile, 0, (now + 2_000) / 1_000);
+			const recoveredAt = 5 * 60 * 60_000;
+			utimesSync(sessionFile, 0, recoveredAt / 1_000);
 			const recovered = subagentsModule.__test__.evaluateNoProgressAdvisory(
 				running,
-				projectLifecycle(running.lifecycle, now + 2_000),
-				now + 2_000,
+				projectLifecycle(running.lifecycle, recoveredAt),
+				recoveredAt,
 				1,
 			);
 			assert.equal(recovered?.kind, "recovered");
+			assert.equal(recovered?.idleMs, recoveredAt);
 			assert.equal(
 				subagentsModule.__test__.evaluateNoProgressAdvisory(
 					running,
-					projectLifecycle(running.lifecycle, now + 130_000),
-					now + 130_000,
+					projectLifecycle(running.lifecycle, recoveredAt + 130_000),
+					recoveredAt + 130_000,
 					1,
 				)?.kind,
 				"warning",
@@ -4716,7 +4777,7 @@ describe("no-progress advisories", () => {
 		});
 	});
 
-	it("ignores idle and interactive runs while fresh heartbeats prevent warnings", () => {
+	it("skips idle runs, resets on fresh heartbeats, and suppresses interactive steers", () => {
 		withTempDir((dir) => {
 			const sessionFile = join(dir, "child.jsonl");
 			writeFileSync(sessionFile, "{}\n");

--- a/test/test.ts
+++ b/test/test.ts
@@ -8,6 +8,7 @@ import {
 	mkdirSync,
 	renameSync,
 	rmSync,
+	utimesSync,
 } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -37,6 +38,7 @@ import {
 	getNewEntries,
 	findLastAssistantMessage,
 	inspectFinalAssistantMessage,
+	inspectNoProgressSessionTail,
 	findObservedSessionRuntime,
 	appendBranchSummary,
 	copySessionFile,
@@ -493,6 +495,71 @@ describe("session.ts", () => {
 				},
 			};
 			assert.equal(findLastAssistantMessage([msg]), null);
+		});
+
+		it("classifies bounded JSONL tails without trusting malformed trailing lines", () => {
+			withTempDir((dir) => {
+				const session = join(dir, "hang.jsonl");
+				const writeTail = (entries: unknown[]) =>
+					writeFileSync(
+						session,
+						`${entries.map((entry) => JSON.stringify(entry)).join("\n")}\n{torn`,
+					);
+				const assistant = (content: unknown[], stopReason?: string) => ({
+					type: "message",
+					id: "assistant",
+					message: { role: "assistant", content, stopReason },
+				});
+
+				writeTail([
+					assistant(
+						[{ type: "toolCall", id: "call-1", name: "bash" }],
+						"toolUse",
+					),
+				]);
+				assert.deepEqual(inspectNoProgressSessionTail(session), {
+					classification: "blocked-tool",
+					lastEntryKind: "assistant",
+				});
+
+				writeTail([
+					assistant(
+						[{ type: "toolCall", id: "call-1", name: "bash" }],
+						"toolUse",
+					),
+					{
+						type: "message",
+						id: "result",
+						message: { role: "toolResult", content: [] },
+					},
+				]);
+				assert.deepEqual(inspectNoProgressSessionTail(session), {
+					classification: "generic-no-progress",
+					lastEntryKind: "tool-result",
+				});
+
+				writeTail([
+					assistant(
+						[
+							{ type: "thinking", thinking: "need a tool" },
+							{ type: "text", text: "Running it." },
+						],
+						"toolUse",
+					),
+				]);
+				assert.deepEqual(inspectNoProgressSessionTail(session), {
+					classification: "truncated-turn",
+					lastEntryKind: "assistant",
+				});
+
+				writeTail([
+					assistant([{ type: "text", text: "still working" }], "stop"),
+				]);
+				assert.deepEqual(inspectNoProgressSessionTail(session), {
+					classification: "generic-no-progress",
+					lastEntryKind: "assistant",
+				});
+			});
 		});
 	});
 
@@ -1916,12 +1983,30 @@ describe("persistent specialist configuration", () => {
 });
 
 describe("supervision", () => {
-	it("parses forcePolling strictly and loads the shared example", () => {
-		assert.deepEqual(parseSupervisionConfig({}), { forcePolling: false });
+	it("parses hang warning configuration strictly and loads the shared example", () => {
+		assert.deepEqual(parseSupervisionConfig({}), {
+			forcePolling: false,
+			hangWarningMinutes: 15,
+		});
 		assert.deepEqual(
-			parseSupervisionConfig({ supervision: { forcePolling: true } }),
-			{ forcePolling: true },
+			parseSupervisionConfig({
+				supervision: { forcePolling: true, hangWarningMinutes: 20 },
+			}),
+			{ forcePolling: true, hangWarningMinutes: 20 },
 		);
+		assert.deepEqual(
+			parseSupervisionConfig({ supervision: { hangWarningMinutes: 0 } }),
+			{ forcePolling: false, hangWarningMinutes: 0 },
+		);
+		for (const value of [-1, 1.5, "15"]) {
+			assert.throws(
+				() =>
+					parseSupervisionConfig({
+						supervision: { hangWarningMinutes: value },
+					}),
+				/supervision\.hangWarningMinutes must be a non-negative integer/,
+			);
+		}
 		assert.throws(
 			() => parseSupervisionConfig({ supervision: { extra: true } }),
 			/supervision has unsupported key\(s\): extra/,
@@ -1930,11 +2015,11 @@ describe("supervision", () => {
 			const example = join(dir, "config.json.example");
 			writeFileSync(
 				example,
-				JSON.stringify({ supervision: { forcePolling: true } }),
+				JSON.stringify({ supervision: { hangWarningMinutes: 20 } }),
 			);
 			assert.deepEqual(
 				loadSupervisionConfig(join(dir, "config.json"), example),
-				{ forcePolling: true },
+				{ forcePolling: false, hangWarningMinutes: 20 },
 			);
 		});
 	});
@@ -4553,6 +4638,129 @@ describe("lifecycle.ts", () => {
 		assert.equal(projection.kind, "active");
 		assert.equal(projection.label, "bash");
 		assert.equal(projection.stateDurationSince, 2_000);
+	});
+});
+
+describe("no-progress advisories", () => {
+	function activeRunning(sessionFile: string, interactive = false) {
+		return {
+			id: "child",
+			name: "Worker",
+			task: "",
+			surface: "pane",
+			startTime: 0,
+			sessionFile,
+			interactive,
+			runtimePlan: undefined,
+			lifecycle: observePaneInspection(
+				createLifecycle(0),
+				{ kind: "present", observedAt: 1, agentStatus: "working" },
+				1,
+			),
+		};
+	}
+
+	it("warns once per active no-progress episode and rearms after durable progress", () => {
+		withTempDir((dir) => {
+			const sessionFile = join(dir, "child.jsonl");
+			writeFileSync(
+				sessionFile,
+				JSON.stringify({
+					type: "message",
+					message: {
+						role: "assistant",
+						content: [{ type: "toolCall", id: "call", name: "bash" }],
+						stopReason: "toolUse",
+					},
+				}) + "\n",
+			);
+			utimesSync(sessionFile, 0, 0);
+			const running = activeRunning(sessionFile);
+			const now = 120_000;
+			const first = subagentsModule.__test__.evaluateNoProgressAdvisory(
+				running,
+				projectLifecycle(running.lifecycle, now),
+				now,
+				1,
+			);
+			assert.equal(first?.kind, "warning");
+			assert.equal(first?.classification, "blocked-tool");
+			assert.equal(first?.lastEntryKind, "assistant");
+			assert.equal(
+				subagentsModule.__test__.evaluateNoProgressAdvisory(
+					running,
+					projectLifecycle(running.lifecycle, now + 1_000),
+					now + 1_000,
+					1,
+				),
+				undefined,
+			);
+
+			utimesSync(sessionFile, 0, (now + 2_000) / 1_000);
+			const recovered = subagentsModule.__test__.evaluateNoProgressAdvisory(
+				running,
+				projectLifecycle(running.lifecycle, now + 2_000),
+				now + 2_000,
+				1,
+			);
+			assert.equal(recovered?.kind, "recovered");
+			assert.equal(
+				subagentsModule.__test__.evaluateNoProgressAdvisory(
+					running,
+					projectLifecycle(running.lifecycle, now + 130_000),
+					now + 130_000,
+					1,
+				)?.kind,
+				"warning",
+			);
+		});
+	});
+
+	it("ignores idle and interactive runs while fresh heartbeats prevent warnings", () => {
+		withTempDir((dir) => {
+			const sessionFile = join(dir, "child.jsonl");
+			writeFileSync(sessionFile, "{}\n");
+			utimesSync(sessionFile, 0, 0);
+			const now = 20 * 60_000;
+			const waiting = activeRunning(sessionFile);
+			waiting.lifecycle = observePaneInspection(
+				waiting.lifecycle,
+				{ kind: "present", observedAt: 2, agentStatus: "idle" },
+				2,
+			);
+			assert.equal(
+				subagentsModule.__test__.evaluateNoProgressAdvisory(
+					waiting,
+					projectLifecycle(waiting.lifecycle, now),
+					now,
+					1,
+				),
+				undefined,
+			);
+
+			const heartbeating = activeRunning(sessionFile);
+			utimesSync(sessionFile, 0, (now - 1) / 1_000);
+			assert.equal(
+				subagentsModule.__test__.evaluateNoProgressAdvisory(
+					heartbeating,
+					projectLifecycle(heartbeating.lifecycle, now),
+					now,
+					1,
+				),
+				undefined,
+			);
+
+			utimesSync(sessionFile, 0, 0);
+			const interactive = activeRunning(sessionFile, true);
+			const event = subagentsModule.__test__.evaluateNoProgressAdvisory(
+				interactive,
+				projectLifecycle(interactive.lifecycle, now),
+				now,
+				1,
+			);
+			assert.equal(event?.kind, "warning");
+			assert.equal(event?.notify, false);
+		});
 	});
 });
 

--- a/test/test.ts
+++ b/test/test.ts
@@ -4777,6 +4777,89 @@ describe("no-progress advisories", () => {
 		});
 	});
 
+	it("formats evidence-based recovery guidance for every child policy", () => {
+		const event = {
+			kind: "warning" as const,
+			idleMs: 60_000,
+			classification: "generic-no-progress" as const,
+			lastEntryKind: "assistant" as const,
+			notify: true,
+		};
+		const running = activeRunning("/tmp/child.jsonl");
+		const worktree = {
+			path: "/tmp/worktree",
+			workspaceId: "workspace",
+			paneId: "pane",
+			branch: "branch",
+			baseRef: "HEAD",
+			baseSha: "sha",
+			manifestFile: "manifest",
+		};
+		const cases = [
+			{
+				name: "ordinary",
+				running,
+				expected:
+					"interrupt, or after manual termination use subagent_resume or a new spawn",
+				forbidden: undefined,
+			},
+			{
+				name: "persistent",
+				running: { ...running, persistent: true },
+				expected:
+					"interrupt, or use subagent_stop then replace with a new persistent specialist",
+				forbidden: /subagent_resume/,
+			},
+			{
+				name: "worktree",
+				running: { ...running, worktree },
+				expected:
+					"interrupt, or retain the workspace and continue there after confirming the previous process exited",
+				forbidden: /subagent_resume|new spawn/,
+			},
+			{
+				name: "persistent worktree",
+				running: { ...running, persistent: true, worktree },
+				expected:
+					"interrupt, or retain the workspace and continue there after confirming the previous process exited",
+				forbidden: /subagent_resume|new persistent specialist/,
+			},
+		];
+
+		for (const testCase of cases) {
+			const line = subagentsModule.__test__.formatNoProgressAdvisoryLine(
+				testCase.running,
+				event,
+			);
+			assert.ok(line.includes(`Recovery options: ${testCase.expected}`));
+			if (testCase.forbidden) assert.doesNotMatch(line, testCase.forbidden);
+			assert.doesNotMatch(line, /cannot self-heal/);
+		}
+
+		const truncated = subagentsModule.__test__.formatNoProgressAdvisoryLine(
+			running,
+			{ ...event, classification: "truncated-turn" },
+		);
+		assert.match(
+			truncated,
+			/truncated-turn; observed toolUse stop with no tool call; cause unknown/,
+		);
+
+		for (const classification of [
+			"blocked-tool",
+			"truncated-turn",
+			"generic-no-progress",
+		] as const) {
+			assert.doesNotMatch(
+				subagentsModule.__test__.formatNoProgressAdvisoryLine(running, {
+					...event,
+					classification,
+				}),
+				/cannot self-heal/,
+			);
+		}
+	});
+
 	it("skips idle runs, resets on fresh heartbeats, and suppresses interactive steers", () => {
 		withTempDir((dir) => {
 			const sessionFile = join(dir, "child.jsonl");


### PR DESCRIPTION
Closes #40.

## Changes

- Add warning-only no-progress detection alongside the existing inspection-failure watchdog. Active/blocked children are evaluated using session JSONL mtime and activity-snapshot updates; idle, interrupted, and finished children are excluded.
- Add strict `supervision.hangWarningMinutes` configuration: default 15 minutes, `0` disables.
- Emit one advisory per episode and a recovery notice when durable progress resumes while active. Interactive children remain quiet. No automatic interruption, termination, retry, or restart.
- Classify observed transcript evidence with a bounded 128 KiB tail read: outstanding tool-call IDs (`blocked-tool`), a `toolUse` stop without a tool call (`truncated-turn`), or `generic-no-progress`. These labels are observations, not proof of a hang's cause or inability to recover.
- Report measured recovery duration and match individual tool-call/result IDs for partially completed parallel calls.
- Make recovery advice respect ordinary, persistent, and managed-worktree policies. Never suggest unsupported persistent/worktree resume or concurrent worktree writers.
- Update README, config example, and CONTEXT glossary. No dependencies or version bump.

## Verification

- Unit tests: 324 passed, none skipped.
- Full deterministic integration suite: 34 passed, none skipped; postflight cleanup complete.
- New hang-advisory coverage uses an injected-clock lifecycle fixture with real session-file evidence. It exercises the evaluator/formatter, not a live hung Pi/Herdr child or the complete status-refresh-to-steer transport.
- Primary LSP diagnostics confirmed all five changed TypeScript files clean.
- Formatting, lint, package preview, whitespace, and empty-root-directory checks passed.
- Independent Claude and Grok reviews covered the feature; Grok reviewed the duration/tool-ID fixes. Parent inspected the final evidence-based wording and policy-aware guidance correction.

## Scope limits

No automatic recovery and no diagnosis of historical pipe inheritance or provider stream truncation. The advisory identifies lack of observed progress; it does not prove a task has failed.
