### PR TITLE
feat(subagents): side-column pane strategy with maxVisible limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,10 +306,21 @@ cp config.json.example config.json
   },
   "panes": {
     "mode": "tab",
-    "direction": "right"
+    "direction": "right",
+    "maxVisible": 0,
+    "sideColumnRatio": 0.34
   }
 }
 ```
+
+Set `panes.mode` to `"side-column"` to keep the parent session on the left
+while subagents stack in a narrow right column (top/middle/bottom) instead of
+opening full tabs. The first subagent splits the parent (`direction`), the
+second splits the side pane down with `sideColumnRatio`, and the rest split
+the last side pane down in even halves — the parent never gets narrower.
+The column chain is file-backed per parent pane, so it survives pi reloads
+and prunes panes closed outside pi. Set `panes.maxVisible` (e.g. `3`) to
+refuse new side panes while the column is full; `0` means unlimited.
 
 If `config.json` is absent, status, role, pane, and persistent-specialist settings fall back to `config.json.example`.
 Model routing does not read the example: no model overrides apply until a real

--- a/config.json.example
+++ b/config.json.example
@@ -17,6 +17,8 @@
   },
   "panes": {
     "mode": "tab",
-    "direction": "right"
+    "direction": "right",
+    "maxVisible": 0,
+    "sideColumnRatio": 0.34
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "format": "biome format --write pi-extension test skills/orchestrate/adversarial-review-example.js",
     "format:check": "biome format pi-extension test skills/orchestrate/adversarial-review-example.js",
     "lint": "oxlint pi-extension test skills/orchestrate/adversarial-review-example.js",
-    "test": "node --experimental-strip-types --test test/test.ts test/launch.test.ts test/runtime-routing.test.ts test/release-workflow.test.ts test/package-skill.test.js test/evals/*.test.mjs",
+    "test": "node --experimental-strip-types --test test/test.ts test/launch.test.ts test/side-column.test.ts test/runtime-routing.test.ts test/release-workflow.test.ts test/package-skill.test.js test/evals/*.test.mjs",
     "test:integration": "node --experimental-strip-types --test --test-concurrency=1 test/integration/*.test.ts",
     "test:integration:live": "PI_TEST_LIVE=1 node --experimental-strip-types --test --test-concurrency=1 test/integration/*.test.ts",
     "version": "auto-changelog --package && git add CHANGELOG.md"

--- a/pi-extension/subagents/herdr.ts
+++ b/pi-extension/subagents/herdr.ts
@@ -113,7 +113,7 @@ async function herdrExecAsync(args: string[]): Promise<string> {
 	return stdout;
 }
 
-function getHerdrParentPaneId(): string {
+export function getHerdrParentPaneId(): string {
 	const paneId = process.env.HERDR_PANE_ID;
 	if (!paneId) {
 		throw new Error("HERDR_PANE_ID not set");
@@ -125,13 +125,13 @@ function buildCurrentPaneArgs(): string[] {
 	return ["pane", "current", "--current"];
 }
 
-interface HerdrCurrentPaneInfo {
+export interface HerdrCurrentPaneInfo {
 	pane_id: string;
 	tab_id: string;
 	workspace_id: string;
 }
 
-function getHerdrCurrentPaneInfo(): HerdrCurrentPaneInfo {
+export function getHerdrCurrentPaneInfo(): HerdrCurrentPaneInfo {
 	const paneId = process.env.HERDR_PANE_ID;
 	const tabId = process.env.HERDR_TAB_ID;
 	const workspaceId = process.env.HERDR_WORKSPACE_ID;
@@ -351,6 +351,54 @@ export function createHerdrWorktree(
 			);
 		}
 		throw parseError;
+	}
+}
+
+export type HerdrSplitTarget =
+	| { kind: "current" }
+	| { kind: "pane"; paneId: string };
+
+function buildSideSplitArgs(
+	target: HerdrSplitTarget,
+	direction: "right" | "down",
+	ratio: number | undefined,
+	cwd: string,
+): string[] {
+	const args = ["pane", "split"];
+	if (target.kind === "current") args.push("--current");
+	else args.push("--pane", target.paneId);
+	args.push("--direction", direction);
+	if (ratio !== undefined) args.push("--ratio", String(ratio));
+	args.push("--no-focus", "--cwd", cwd);
+	return args;
+}
+
+/** Split for the side-column layout and return the child pane ID. */
+export function createHerdrSideSplit(
+	name: string,
+	target: HerdrSplitTarget,
+	direction: "right" | "down",
+	ratio: number | undefined,
+): string {
+	const output = herdrExec(
+		buildSideSplitArgs(target, direction, ratio, process.cwd()),
+	);
+	const paneId = extractHerdrPaneId(output, "pane split");
+	try {
+		herdrExec(["pane", "rename", paneId, name]);
+	} catch {
+		// Optional.
+	}
+	return paneId;
+}
+
+/** Sync pane ID list for layout decisions; null when unverifiable. */
+export function listHerdrPaneIdsSync(): string[] | null {
+	try {
+		const entries = parseHerdrPaneSnapshot(herdrExec(["pane", "list"]));
+		return entries === null ? null : entries.map((entry) => entry.paneId);
+	} catch {
+		return null;
 	}
 }
 

--- a/pi-extension/subagents/launch.ts
+++ b/pi-extension/subagents/launch.ts
@@ -23,6 +23,7 @@ import {
 } from "./session.ts";
 import {
 	closePane,
+	createSideColumnPane,
 	createSubagentPane,
 	createSubagentWorktree,
 	splitCurrentPane,
@@ -189,6 +190,7 @@ const defaultOperations: PiLaunchOperations = {
 		paneConfig,
 		createSubagentPane,
 		splitCurrentPane,
+		(name) => createSideColumnPane(name, paneConfig),
 	),
 	createWorktree: createSubagentWorktree,
 	waitForShellReady,

--- a/pi-extension/subagents/pane-config.ts
+++ b/pi-extension/subagents/pane-config.ts
@@ -1,19 +1,25 @@
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { isPlainObject, isString } from "./type-guards.ts";
+import { isFiniteNumber, isPlainObject, isString } from "./type-guards.ts";
 
 const PACKAGE_ROOT = join(dirname(fileURLToPath(import.meta.url)), "../..");
 const DEFAULT_PANE_CONFIG_PATH = join(PACKAGE_ROOT, "config.json");
 const PANE_CONFIG_EXAMPLE_PATH = join(PACKAGE_ROOT, "config.json.example");
 
-export type PaneMode = "tab" | "split";
+export type PaneMode = "tab" | "split" | "side-column";
 export type PaneDirection = "right" | "down";
 
 export interface PaneConfig {
 	mode: PaneMode;
 	direction: PaneDirection;
+	/** Max visible side-column panes per tab (0 = unlimited). Only used by side-column mode. */
+	maxVisible: number;
+	/** Split ratio applied when the second side-column pane opens. (0, 1) exclusive. */
+	sideColumnRatio: number;
 }
+
+export const DEFAULT_SIDE_COLUMN_RATIO = 0.34;
 
 type PaneCreator = (name: string) => string;
 type SplitPaneCreator = (name: string, direction: PaneDirection) => string;
@@ -30,14 +36,23 @@ export function parsePaneConfig(
 		invalidPaneConfig(source, "root must be an object");
 	}
 	if (!Object.hasOwn(rawConfig, "panes")) {
-		return { mode: "tab", direction: "right" };
+		return {
+			mode: "tab",
+			direction: "right",
+			maxVisible: 0,
+			sideColumnRatio: DEFAULT_SIDE_COLUMN_RATIO,
+		};
 	}
 	if (!isPlainObject(rawConfig.panes)) {
 		invalidPaneConfig(source, "panes must be an object");
 	}
 
 	const unsupportedKeys = Object.keys(rawConfig.panes).filter(
-		(key) => key !== "mode" && key !== "direction",
+		(key) =>
+			key !== "mode" &&
+			key !== "direction" &&
+			key !== "maxVisible" &&
+			key !== "sideColumnRatio",
 	);
 	if (unsupportedKeys.length > 0) {
 		invalidPaneConfig(
@@ -50,9 +65,14 @@ export function parsePaneConfig(
 	if (Object.hasOwn(rawConfig.panes, "mode")) {
 		if (
 			!isString(rawConfig.panes.mode) ||
-			(rawConfig.panes.mode !== "tab" && rawConfig.panes.mode !== "split")
+			(rawConfig.panes.mode !== "tab" &&
+				rawConfig.panes.mode !== "split" &&
+				rawConfig.panes.mode !== "side-column")
 		) {
-			invalidPaneConfig(source, 'panes.mode must be "tab" or "split"');
+			invalidPaneConfig(
+				source,
+				'panes.mode must be "tab", "split", or "side-column"',
+			);
 		}
 		mode = rawConfig.panes.mode;
 	}
@@ -69,7 +89,37 @@ export function parsePaneConfig(
 		direction = rawConfig.panes.direction;
 	}
 
-	return { mode, direction };
+	let maxVisible = 0;
+	if (Object.hasOwn(rawConfig.panes, "maxVisible")) {
+		if (
+			!isFiniteNumber(rawConfig.panes.maxVisible) ||
+			!Number.isInteger(rawConfig.panes.maxVisible) ||
+			rawConfig.panes.maxVisible < 0
+		) {
+			invalidPaneConfig(
+				source,
+				"panes.maxVisible must be a non-negative integer (0 = unlimited)",
+			);
+		}
+		maxVisible = rawConfig.panes.maxVisible;
+	}
+
+	let sideColumnRatio = DEFAULT_SIDE_COLUMN_RATIO;
+	if (Object.hasOwn(rawConfig.panes, "sideColumnRatio")) {
+		if (
+			!isFiniteNumber(rawConfig.panes.sideColumnRatio) ||
+			rawConfig.panes.sideColumnRatio <= 0 ||
+			rawConfig.panes.sideColumnRatio >= 1
+		) {
+			invalidPaneConfig(
+				source,
+				"panes.sideColumnRatio must be a number between 0 and 1 (exclusive)",
+			);
+		}
+		sideColumnRatio = rawConfig.panes.sideColumnRatio;
+	}
+
+	return { mode, direction, maxVisible, sideColumnRatio };
 }
 
 interface PaneConfigSource {
@@ -128,7 +178,13 @@ export function createSubagentPaneFactory(
 	config: PaneConfig,
 	createTab: PaneCreator,
 	createSplit: SplitPaneCreator,
+	createSideColumn?: PaneCreator,
 ): PaneCreator {
+	if (config.mode === "side-column") {
+		// Older callers pass only tab/split creators; fall back to a plain
+		// split of the current pane rather than crashing.
+		return createSideColumn ?? ((name) => createSplit(name, config.direction));
+	}
 	return config.mode === "split"
 		? (name) => createSplit(name, config.direction)
 		: createTab;

--- a/pi-extension/subagents/side-column.ts
+++ b/pi-extension/subagents/side-column.ts
@@ -1,0 +1,171 @@
+import {
+	mkdirSync,
+	readFileSync,
+	renameSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { isNonEmptyString, isPlainObject } from "./type-guards.ts";
+
+/**
+ * Side-column layout: the parent session keeps the left side of the tab
+ * while subagents stack in a narrow right column (top/middle/bottom).
+ *
+ * - 1st pane: split the parent to the right (full-height column).
+ * - 2nd pane: split the last side pane downward with `ratio`.
+ * - 3rd+ pane: split the last side pane downward (even halves).
+ *
+ * Splitting the last side pane — never the parent — keeps the parent wide
+ * no matter how many side panes open. A file-backed chain (one per parent
+ * pane) tracks the column so the layout survives pi reloads; dead panes are
+ * pruned against the live pane list on every launch.
+ */
+
+export type SideColumnTarget =
+	| { kind: "current" }
+	| { kind: "pane"; paneId: string };
+
+export interface SideColumnSplitPlan {
+	target: SideColumnTarget;
+	direction: "right" | "down";
+	ratio?: number;
+}
+
+export interface SideColumnState {
+	tabId: string;
+	chain: string[];
+}
+
+export interface SideColumnOptions {
+	/** Direction of the first split (the column side). */
+	firstDirection: "right" | "down";
+	/** Ratio for the second pane's split. */
+	ratio: number;
+	/** Max side panes per tab (0 = unlimited). */
+	maxVisible: number;
+}
+
+/** Pure: decide the next split from the pruned chain. */
+export function planSideColumnSplit(
+	chain: string[],
+	firstDirection: "right" | "down",
+	ratio: number,
+): SideColumnSplitPlan {
+	if (chain.length === 0) {
+		return { target: { kind: "current" }, direction: firstDirection };
+	}
+	const plan: SideColumnSplitPlan = {
+		target: { kind: "pane", paneId: chain[chain.length - 1] },
+		direction: "down",
+	};
+	if (chain.length === 1) plan.ratio = ratio;
+	return plan;
+}
+
+/** Pure: drop chain entries that are no longer alive. */
+export function pruneSideChain(
+	chain: string[],
+	aliveIds: Set<string> | string[],
+): string[] {
+	const alive = Array.isArray(aliveIds) ? new Set(aliveIds) : aliveIds;
+	return chain.filter((id) => alive.has(id));
+}
+
+function agentDir(): string {
+	return process.env.PI_CODING_AGENT_DIR ?? join(homedir(), ".pi", "agent");
+}
+
+export function sideColumnStateDir(
+	dir = join(agentDir(), "tmp", "side-column"),
+): string {
+	return dir;
+}
+
+export function sideColumnStateFile(
+	parentPaneId: string,
+	dir = sideColumnStateDir(),
+): string {
+	const safe = parentPaneId.replace(/[^A-Za-z0-9_-]/g, "_");
+	return join(dir, `${safe}.json`);
+}
+
+export function loadSideColumnState(path: string): SideColumnState | null {
+	let raw: string;
+	try {
+		raw = readFileSync(path, "utf8");
+	} catch {
+		return null;
+	}
+	try {
+		const parsed = JSON.parse(raw);
+		if (!isPlainObject(parsed)) return null;
+		if (!isNonEmptyString(parsed.tabId)) return null;
+		if (!Array.isArray(parsed.chain)) return null;
+		const chain: string[] = [];
+		for (const id of parsed.chain) {
+			if (isNonEmptyString(id)) chain.push(id);
+		}
+		return { tabId: parsed.tabId, chain };
+	} catch {
+		return null;
+	}
+}
+
+export function saveSideColumnState(
+	path: string,
+	state: SideColumnState,
+): void {
+	mkdirSync(dirname(path), { recursive: true });
+	const tmp = `${path}.${process.pid}.tmp`;
+	writeFileSync(tmp, JSON.stringify(state), "utf8");
+	try {
+		renameSync(tmp, path);
+	} catch {
+		writeFileSync(path, JSON.stringify(state), "utf8");
+		try {
+			unlinkSync(tmp);
+		} catch {}
+	}
+}
+
+export interface SideColumnDeps {
+	tabId: string;
+	listAlivePaneIds(): string[] | null;
+	split(name: string, plan: SideColumnSplitPlan): string;
+	loadState(): SideColumnState | null;
+	saveState(state: SideColumnState): void;
+}
+
+/**
+ * Resolve the next side-column split, enforce maxVisible, and persist the
+ * chain. Throws when the column is full so the caller can surface the
+ * refusal to the model before Herdr creates anything.
+ */
+export function createSideColumnPane(
+	name: string,
+	options: SideColumnOptions,
+	deps: SideColumnDeps,
+): string {
+	const stored = deps.loadState();
+	const previous = stored && stored.tabId === deps.tabId ? stored.chain : [];
+	const alive = deps.listAlivePaneIds();
+	// Fail closed: when the live list is unavailable, keep the stored chain
+	// so a blind launch cannot silently overflow the tab.
+	const chain = alive === null ? previous : pruneSideChain(previous, alive);
+	if (options.maxVisible > 0 && chain.length >= options.maxVisible) {
+		throw new Error(
+			`Side column is full (${chain.length}/${options.maxVisible} visible panes). ` +
+				`Wait for a running subagent to finish, or stop one, then retry.`,
+		);
+	}
+	const plan = planSideColumnSplit(
+		chain,
+		options.firstDirection,
+		options.ratio,
+	);
+	const paneId = deps.split(name, plan);
+	deps.saveState({ tabId: deps.tabId, chain: [...chain, paneId] });
+	return paneId;
+}

--- a/pi-extension/subagents/terminal.ts
+++ b/pi-extension/subagents/terminal.ts
@@ -3,11 +3,15 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import {
 	closeHerdrSurface,
+	createHerdrSideSplit,
 	createHerdrSurface,
 	createHerdrSurfaceSplit,
 	createHerdrWorktree,
 	focusHerdrWorkspace,
+	getHerdrCurrentPaneInfo,
+	getHerdrParentPaneId,
 	getHerdrPaneProcessInfo,
+	listHerdrPaneIdsSync,
 	waitForHerdrPiReady,
 	waitForHerdrShellReady,
 	isHerdrAvailable,
@@ -23,7 +27,16 @@ import {
 	waitForHerdrPaneAbsence,
 	waitForProcessesExit,
 	type HerdrPaneProcessInfo,
+	type HerdrSplitTarget,
 } from "./herdr.ts";
+import type { PaneConfig } from "./pane-config.ts";
+import {
+	createSideColumnPane as resolveSideColumnPane,
+	loadSideColumnState,
+	saveSideColumnState,
+	sideColumnStateFile,
+	type SideColumnSplitPlan,
+} from "./side-column.ts";
 
 export type PaneId = string;
 export type SplitDirection = "right" | "down";
@@ -72,6 +85,43 @@ export function splitCurrentPane(
 ): PaneId {
 	assertTerminalAvailable();
 	return createHerdrSurfaceSplit(name, direction);
+}
+
+/**
+ * Open the next slot of the side column (parent stays left, subagents stack
+ * right) and return the child pane ID. The column chain is file-backed per
+ * parent pane, so it survives pi reloads; dead panes are pruned live.
+ */
+export function createSideColumnPane(name: string, config: PaneConfig): PaneId {
+	assertTerminalAvailable();
+	const parentPaneId = getHerdrParentPaneId();
+	const statePath = sideColumnStateFile(parentPaneId);
+	return resolveSideColumnPane(
+		name,
+		{
+			firstDirection: config.direction,
+			ratio: config.sideColumnRatio,
+			maxVisible: config.maxVisible,
+		},
+		{
+			tabId: getHerdrCurrentPaneInfo().tab_id,
+			listAlivePaneIds: () => listHerdrPaneIdsSync(),
+			split: (splitName: string, plan: SideColumnSplitPlan) => {
+				const target: HerdrSplitTarget =
+					plan.target.kind === "current"
+						? { kind: "current" }
+						: { kind: "pane", paneId: plan.target.paneId };
+				return createHerdrSideSplit(
+					splitName,
+					target,
+					plan.direction,
+					plan.ratio,
+				);
+			},
+			loadState: () => loadSideColumnState(statePath),
+			saveState: (state) => saveSideColumnState(statePath, state),
+		},
+	);
 }
 
 export function renameCurrentTab(title: string): void {

--- a/test/side-column.test.ts
+++ b/test/side-column.test.ts
@@ -1,0 +1,205 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	createSideColumnPane,
+	loadSideColumnState,
+	planSideColumnSplit,
+	pruneSideChain,
+	saveSideColumnState,
+	sideColumnStateFile,
+	type SideColumnDeps,
+	type SideColumnState,
+} from "../pi-extension/subagents/side-column.ts";
+import { createSubagentPaneFactory } from "../pi-extension/subagents/pane-config.ts";
+
+const OPTIONS = {
+	firstDirection: "right" as const,
+	ratio: 0.34,
+	maxVisible: 3,
+};
+
+interface SplitCall {
+	name: string;
+	target: string;
+	direction: string;
+	ratio?: number;
+}
+
+function fakeDeps(
+	overrides: Partial<{
+		tabId: string;
+		alive: string[] | null;
+		stored: SideColumnState | null;
+	}> = {},
+) {
+	const splits: SplitCall[] = [];
+	let counter = 0;
+	let saved: SideColumnState | null = null;
+	const deps: SideColumnDeps = {
+		tabId: overrides.tabId ?? "tab-1",
+		listAlivePaneIds: () => overrides.alive ?? null,
+		split: (name, plan) => {
+			const target =
+				plan.target.kind === "current" ? "current" : plan.target.paneId;
+			splits.push({
+				name,
+				target,
+				direction: plan.direction,
+				ratio: plan.ratio,
+			});
+			counter += 1;
+			return `side-${counter}`;
+		},
+		loadState: () => overrides.stored ?? saved,
+		saveState: (state) => {
+			saved = state;
+		},
+	};
+	return { deps, splits, saved: () => saved };
+}
+
+describe("planSideColumnSplit", () => {
+	it("splits the parent right on an empty chain", () => {
+		assert.deepEqual(planSideColumnSplit([], "right", 0.34), {
+			target: { kind: "current" },
+			direction: "right",
+		});
+	});
+
+	it("splits the last side pane down with ratio on the second slot", () => {
+		assert.deepEqual(planSideColumnSplit(["p1"], "right", 0.34), {
+			target: { kind: "pane", paneId: "p1" },
+			direction: "down",
+			ratio: 0.34,
+		});
+	});
+
+	it("splits the last side pane down without ratio afterwards", () => {
+		assert.deepEqual(planSideColumnSplit(["p1", "p2"], "right", 0.34), {
+			target: { kind: "pane", paneId: "p2" },
+			direction: "down",
+		});
+	});
+});
+
+describe("pruneSideChain", () => {
+	it("drops dead panes and keeps order", () => {
+		assert.deepEqual(pruneSideChain(["a", "b", "c"], ["c", "a"]), ["a", "c"]);
+	});
+});
+
+describe("side-column state file", () => {
+	it("round-trips and rejects corrupt files", () => {
+		const dir = mkdtempSync(join(tmpdir(), "side-column-state-"));
+		const path = sideColumnStateFile("wB:p2D", dir);
+		assert.equal(loadSideColumnState(path), null);
+		saveSideColumnState(path, { tabId: "t1", chain: ["a"] });
+		assert.deepEqual(loadSideColumnState(path), { tabId: "t1", chain: ["a"] });
+		const raw = JSON.parse(readFileSync(path, "utf8"));
+		assert.equal(raw.tabId, "t1");
+		writeFileSync(path, "not json");
+		assert.equal(loadSideColumnState(path), null);
+	});
+});
+
+describe("createSideColumnPane", () => {
+	it("stacks three panes: right, down+ratio, down", () => {
+		const alive = ["parent"];
+		const { deps, splits, saved } = fakeDeps({ alive });
+		const first = createSideColumnPane("one", OPTIONS, deps);
+		alive.push(first);
+		const second = createSideColumnPane("two", OPTIONS, deps);
+		alive.push(second);
+		createSideColumnPane("three", OPTIONS, deps);
+		assert.deepEqual(
+			splits.map((s) => [s.target, s.direction, s.ratio]),
+			[
+				["current", "right", undefined],
+				[first, "down", 0.34],
+				[second, "down", undefined],
+			],
+		);
+		assert.deepEqual(saved()?.chain, [first, second, "side-3"]);
+	});
+
+	it("refuses new panes when the column is full", () => {
+		const { deps } = fakeDeps({
+			alive: ["parent", "s1", "s2", "s3"],
+			stored: { tabId: "tab-1", chain: ["s1", "s2", "s3"] },
+		});
+		assert.throws(
+			() => createSideColumnPane("fourth", OPTIONS, deps),
+			/Side column is full \(3\/3 visible panes\)/,
+		);
+	});
+
+	it("frees slots for panes closed outside pi", () => {
+		const { deps, splits } = fakeDeps({
+			alive: ["parent", "s1", "s3"],
+			stored: { tabId: "tab-1", chain: ["s1", "s2", "s3"] },
+		});
+		createSideColumnPane("next", OPTIONS, deps);
+		assert.equal(splits[0].target, "s3");
+	});
+
+	it("starts a fresh column when the parent moved tabs", () => {
+		const { deps, splits } = fakeDeps({
+			tabId: "tab-2",
+			alive: ["parent", "old-1"],
+			stored: { tabId: "tab-1", chain: ["old-1"] },
+		});
+		createSideColumnPane("next", OPTIONS, deps);
+		assert.equal(splits[0].target, "current");
+	});
+
+	it("fails closed when the live pane list is unavailable", () => {
+		const { deps } = fakeDeps({
+			alive: null,
+			stored: { tabId: "tab-1", chain: ["s1", "s2", "s3"] },
+		});
+		assert.throws(
+			() => createSideColumnPane("next", OPTIONS, deps),
+			/Side column is full/,
+		);
+	});
+
+	it("treats maxVisible 0 as unlimited", () => {
+		const { deps, splits } = fakeDeps({
+			alive: ["parent", "s1", "s2", "s3"],
+			stored: { tabId: "tab-1", chain: ["s1", "s2", "s3"] },
+		});
+		createSideColumnPane("next", { ...OPTIONS, maxVisible: 0 }, deps);
+		assert.equal(splits.length, 1);
+	});
+});
+
+describe("side-column factory routing", () => {
+	const config = {
+		mode: "side-column" as const,
+		direction: "right" as const,
+		maxVisible: 0,
+		sideColumnRatio: 0.34,
+	};
+
+	it("routes side-column mode to the side creator", () => {
+		const factory = createSubagentPaneFactory(
+			config,
+			() => "tab-pane",
+			() => "split-pane",
+			() => "side-pane",
+		);
+		assert.equal(factory("Scout"), "side-pane");
+	});
+
+	it("falls back to a plain split without a side creator", () => {
+		const factory = createSubagentPaneFactory(
+			config,
+			() => "tab-pane",
+			(_name, direction) => `split-pane:${direction}`,
+		);
+		assert.equal(factory("Scout"), "split-pane:right");
+	});
+});

--- a/test/test.ts
+++ b/test/test.ts
@@ -1909,13 +1909,39 @@ describe("pane configuration", () => {
 		assert.deepEqual(parsePaneConfig({}), {
 			mode: "tab",
 			direction: "right",
+			maxVisible: 0,
+			sideColumnRatio: 0.34,
 		});
 	});
 
 	it("parses split mode and direction", () => {
 		assert.deepEqual(
 			parsePaneConfig({ panes: { mode: "split", direction: "down" } }),
-			{ mode: "split", direction: "down" },
+			{
+				mode: "split",
+				direction: "down",
+				maxVisible: 0,
+				sideColumnRatio: 0.34,
+			},
+		);
+	});
+
+	it("parses side-column mode with limits", () => {
+		assert.deepEqual(
+			parsePaneConfig({
+				panes: {
+					mode: "side-column",
+					direction: "right",
+					maxVisible: 3,
+					sideColumnRatio: 0.5,
+				},
+			}),
+			{
+				mode: "side-column",
+				direction: "right",
+				maxVisible: 3,
+				sideColumnRatio: 0.5,
+			},
 		);
 	});
 
@@ -1928,7 +1954,7 @@ describe("pane configuration", () => {
 		}
 		assert.throws(
 			() => parsePaneConfig({ panes: { mode: "window" } }),
-			/panes\.mode must be "tab" or "split"/,
+			/panes\.mode must be "tab", "split", or "side-column"/,
 		);
 		assert.throws(
 			() => parsePaneConfig({ panes: { direction: "left" } }),
@@ -1937,6 +1963,22 @@ describe("pane configuration", () => {
 		assert.throws(
 			() => parsePaneConfig({ panes: { mode: "tab", extra: true } }),
 			/panes has unsupported key\(s\): extra/,
+		);
+		assert.throws(
+			() => parsePaneConfig({ panes: { maxVisible: -1 } }),
+			/panes\.maxVisible must be a non-negative integer/,
+		);
+		assert.throws(
+			() => parsePaneConfig({ panes: { maxVisible: 1.5 } }),
+			/panes\.maxVisible must be a non-negative integer/,
+		);
+		assert.throws(
+			() => parsePaneConfig({ panes: { sideColumnRatio: 0 } }),
+			/panes\.sideColumnRatio must be a number between 0 and 1/,
+		);
+		assert.throws(
+			() => parsePaneConfig({ panes: { sideColumnRatio: 1 } }),
+			/panes\.sideColumnRatio must be a number between 0 and 1/,
 		);
 	});
 
@@ -1951,6 +1993,8 @@ describe("pane configuration", () => {
 			assert.deepEqual(loadPaneConfig(join(dir, "config.json"), examplePath), {
 				mode: "split",
 				direction: "down",
+				maxVisible: 0,
+				sideColumnRatio: 0.34,
 			});
 		});
 	});


### PR DESCRIPTION
## What

New `panes.mode: "side-column"` for ordinary (non-worktree) subagent panes.
Instead of opening a full tab per child (`tab`) or repeatedly splitting the
parent pane (`split`), the parent session keeps the left side of the tab
while subagents stack in a narrow right column:

- 1st child: split the parent to the configured `direction` (default `right`)
- 2nd child: split the last side pane down with `panes.sideColumnRatio` (default `0.34`)
- 3rd+ child: split the last side pane down in even halves

The parent never gets narrower no matter how many side panes open. This is
the layout `split` mode cannot express: it always re-splits the parent, so
parallel children slice the working pane ever thinner (the exact failure
noted in `createHerdrSurface`: "instead of ever-narrower splits of the
parent pane").

## Limit

`panes.maxVisible` (default `0` = unlimited) refuses new side panes while
the column is full, before Herdr creates anything:

```
Side column is full (3/3 visible panes). Wait for a running subagent to
finish, or stop one, then retry.
```

## State

The column chain is file-backed per parent pane
(`$PI_CODING_AGENT_DIR/tmp/side-column/<pane>.json`), so it survives pi
reloads. Dead panes (closed outside pi) are pruned against the live pane
list on every launch; a parent that moved tabs starts a fresh column. When
the live list is unreachable, the stored chain is kept (fail closed).

## Compatibility

- `tab` and `split` behavior unchanged; new config keys default to old behavior.
- `createSubagentPaneFactory` takes an optional 4th creator; old 3-arg
callers fall back to a plain split for `side-column` instead of crashing.

## Verification

- 13 new unit tests (`test/side-column.test.ts`): planning, pruning,
state round-trip, limit, tab-change reset, fail-closed, factory routing.
- Full suite green: `test/test.ts` 270/270, `launch.test.ts` 20/20.
- `oxlint` + `biome format` clean.
- Live-verified in Herdr: 3 parallel children produced parent-left (77x77)
+ stacked right column (26/26/25 rows), no focus steal, 4th launch refused.

## Config

```json
"panes": {
  "mode": "side-column",
  "direction": "right",
  "maxVisible": 3,
  "sideColumnRatio": 0.34
}
```