### PR TITLE
feat(subagents): checkout-aware Agents tabs and safe cleanup (#33)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ These instructions apply to humans and coding agents changing `pi-herdr-agents`.
 
 ## What this package is
 
-`pi-herdr-agents` (Pi Herdr Agents) is a Pi extension that launches asynchronous Pi child agents exclusively in Herdr. Ordinary runs use dedicated Herdr panes/tabs. Writing tasks may opt into one isolated Herdr-managed Git worktree per branch. Legacy role definitions that request an external CLI fail before Herdr creates resources.
+`pi-herdr-agents` (Pi Herdr Agents) is a Pi extension that launches asynchronous Pi child agents exclusively in Herdr. Ordinary runs group child panes in extension-owned `Agents` tabs by default. Writing tasks may opt into one isolated Herdr-managed Git worktree per branch. Legacy role definitions that request an external CLI fail before Herdr creates resources.
 
 The extension is fire-and-forget: `subagent` returns an acknowledgement, and completion is delivered to the parent automatically. Never add polling guidance that tells callers to sleep, tail sessions, or repeatedly check status.
 
@@ -22,7 +22,7 @@ Bundled role prompts live in [`agents/`](agents/). The native `/skill:orchestrat
 ## Code map
 
 - `pi-extension/subagents/index.ts` — public tools/commands, agent discovery, launch/watch lifecycle, completion delivery, worktree manifests and handoffs
-- `pi-extension/subagents/herdr.ts` — Herdr CLI argument construction and response parsing
+- `pi-extension/subagents/herdr.ts` — Herdr CLI calls, response parsing, and ID-based Agents tab placement and capacity
 - `pi-extension/subagents/terminal.ts` — terminal adapter used by the lifecycle
 - `pi-extension/subagents/lifecycle.ts`, `status.ts`, `activity.ts` — process/turn state and widget projection
 - `pi-extension/subagents/wake.ts`, `supervision.ts`, `supervision-config.ts` — file wake-ups, shared pane reconciliation, polling fallback, and supervision configuration

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -82,6 +82,19 @@ The append-only evidence record of persistent task dispatch and terminal
 outcomes for one session generation.
 _Avoid_: Work queue, mutable task list
 
+**Agents tab**:
+An extension-owned Herdr tab grouping delegated child panes in an existing
+checkout workspace. Ownership comes from returned IDs, not its display label.
+The pane cap includes every live pane; overflow creates another tab, not a
+workspace. Separate parent processes own separate groups.
+_Avoid_: Agent workspace, label-based ownership, automatic rearrangement
+
+**Retained checkout shell**:
+The interactive shell in a managed worktree's root pane, preserved after the
+child Pi process exits. Temporary review panes can close without deleting this
+surface or its checkout.
+_Avoid_: Completed agent process, disposable pane, automatic worktree cleanup
+
 **Worktree lease**:
 The lifetime-exclusive binding between a persistent specialist generation and
 one managed worktree, when that specialist writes in a worktree.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Use ordinary panes for read-only agents. A single or sequential writer can work 
 
 ![Pi Herdr Agents lifecycle: spawn a child, run it in Herdr, supervise live state, and deliver one bounded result to the parent.](https://raw.githubusercontent.com/giuseppecrj/pi-herdr-agents/main/docs/assets/async-subagent-lifecycle.png)
 
-A `subagent` call creates a dedicated Herdr pane or worktree, launches a child Pi session, and returns `started`. The parent watcher combines Herdr process state with child activity details and projects the result into a live widget:
+A `subagent` call selects the target checkout, reuses its Herdr workspace, and gives the child a pane in an extension-owned `Agents` tab. Four panes fit in each tab by default; overflow opens another tab in the same workspace. A worktree is created only when explicitly requested for checkout isolation. The call launches a child Pi session and returns `started`. The parent watcher combines Herdr process state with child activity details and projects the result into a live widget:
 
 ```text
 ╭─ Subagents ──────────────────── 1 active · 1 open ─╮
@@ -92,7 +92,7 @@ A `subagent` call creates a dedicated Herdr pane or worktree, launches a child P
 ╰────────────────────────────────────────────────────╯
 ```
 
-When the child completes, the parent receives one bounded `subagent_result` message and starts a new turn with that result in context. Callers never need to poll, tail session files, or wait in a shell loop.
+When the child completes, the parent receives one bounded `subagent_result` message and starts a new turn with that result in context. Disposable ordinary panes close after result delivery; Herdr removes a tab when its last pane closes. Persistent specialists keep their pane between tasks, and managed worktree roots return to retained interactive shells. Callers never need to poll, tail session files, or wait in a shell loop.
 
 ## Troubleshooting completion delivery
 
@@ -305,8 +305,9 @@ cp config.json.example config.json
     "hangWarningMinutes": 15
   },
   "panes": {
-    "mode": "tab",
-    "direction": "right"
+    "mode": "grouped",
+    "direction": "right",
+    "maxPerTab": 4
   }
 }
 ```
@@ -388,7 +389,13 @@ was 4.82 s. The benchmark measures `/proc` CPU ticks for the supervisor and
 isolated Herdr tree, not parent-model latency; raw samples are written to
 `/tmp/issue29-bench/` by `test/bench/supervision-bench.mjs`.
 
-Set `panes.mode` to `"split"` to open ordinary public `subagent` and `subagent_resume` launches, including bare forks and `/iterate`, as splits of the stable parent pane. Set `panes.direction` to `"right"` or `"down"`; it defaults to `"right"` and is ignored when mode is `"tab"`. The default `"tab"` mode preserves existing behavior. Managed worktrees still use separate workspaces, while `/btw` keeps its existing tab behavior.
+`panes.mode` defaults to `"grouped"` when omitted. Ordinary public `subagent` and `subagent_resume` launches, including bare forks and `/iterate`, fill extension-owned `Agents`, `Agents 2`, etc. tabs in the target checkout's existing workspace. `panes.maxPerTab` is a positive safe integer, defaults to `4`, and counts all live panes in each owned tab, including user-added panes and retained shells. Overlapping launches in one parent respect this cap. It is independent of `persistent.maxAgents`.
+
+Checkout matching uses Herdr's canonical `worktree.checkout_path` and includes descendant directories. Shell working directories do not establish workspace ownership. If no checkout matches (including non-Git directories), placement uses the caller's workspace; overflow never creates a workspace. A reviewer with `cwd` set to a managed checkout joins that workspace without creating another worktree. Resume placement uses the saved session's cwd.
+
+Explicit `panes.mode: "tab"` preserves one new tab per ordinary child in the caller's workspace. Explicit `"split"` preserves splits of the stable parent pane. `panes.direction` is `"right"` (default) or `"down"` and applies to grouped and legacy splits. `maxPerTab` does not affect these legacy modes. Managed worktrees retain their separate workspaces, while `/btw` keeps its existing tab behavior.
+
+Ownership is tracked by returned pane/tab/workspace IDs, never labels. Separate parent processes own separate groups; `/reload` preserves a parent's in-memory ownership, but a full restart does not adopt old tabs. Placement never moves existing panes or renames user tabs. Background launches preserve focus; Herdr may resize sibling panes when splitting or closing. User-added panes are never closed by automatic tab cleanup. An owned tab remains reusable while user panes remain, even after all child panes close.
 
 Run `/reload` after changing role, model, or pane settings.
 
@@ -486,7 +493,7 @@ A launch with `worktree` and an effective bundled `scout`, `reviewer`, or `adver
 
 The child starts at the returned worktree root. Tell writing agents to test and commit when you want a commit-based handoff, and tell them not to push, merge, switch branches, or remove the worktree. The parent owns review and integration.
 
-Successful, failed, and help-requesting runs retain their workspace. Completion includes the worktree path, Herdr workspace, branch, base/head SHAs, commits ahead, changed and untracked files, and clean/dirty/conflicted state. Here, `clean` means no uncommitted files; the branch may still contain commits. If Git inspection fails, state is reported as unknown rather than guessed.
+Successful, failed, and help-requesting worktree runs retain their workspace and root shell. A reviewer's disposable pane can close without closing that root, tab, or checkout. Completion includes the worktree path, Herdr workspace, branch, base/head SHAs, commits ahead, changed and untracked files, and clean/dirty/conflicted state. Here, `clean` means no uncommitted files; the branch may still contain commits. If Git inspection fails, state is reported as unknown rather than guessed.
 
 An ownership manifest is written under the parent session's `artifacts/<session-id>/worktree-runs/` directory before Herdr creates resources. V1 does not automatically recover watchers after a full process restart, and `subagent_resume` does not reattach the managed worktree lifecycle.
 
@@ -597,7 +604,7 @@ Phase 5: Integrate        → Parent reviews and integrates worktree branches on
 Phase 6: Review           → Reviewer subagent checks the integrated changes
 ```
 
-The parent workspace and tab names stay unchanged. Subagents are created in newly named tabs or panes for each phase.
+The parent workspace and tab names stay unchanged. Subagents use the configured placement policy; grouped mode reuses available space in owned Agents tabs.
 
 ---
 

--- a/config.json.example
+++ b/config.json.example
@@ -16,7 +16,8 @@
     "hangWarningMinutes": 15
   },
   "panes": {
-    "mode": "tab",
-    "direction": "right"
+    "mode": "grouped",
+    "direction": "right",
+    "maxPerTab": 4
   }
 }

--- a/docs/worktree-subagents.md
+++ b/docs/worktree-subagents.md
@@ -46,7 +46,7 @@ For a worktree launch:
 - `worktree.branch` is a new, unique branch name. Git/Herdr rejects a branch that cannot be created or is already checked out elsewhere.
 - `worktree.base` may be any revision that resolves to a commit in the source repository. It defaults to committed `HEAD`.
 - The extension resolves `base` to an exact SHA, writes an ownership manifest, then calls `herdr worktree create --no-focus`.
-- The child starts at the root of the returned worktree, in that workspace's root pane.
+- The child starts at the root of the returned worktree, in that workspace's retained root pane and newly owned `Agents` tab. Finishing Pi returns to the interactive checkout shell; it does not close the root pane.
 - Uncommitted and untracked files from the parent checkout are not copied. Commit anything the child must see before spawning it, or pass the needed context in the task.
 - Worktree creation does not steal terminal focus.
 
@@ -139,7 +139,7 @@ For parallel read-only review, prepare one stable existing checkout of the pull 
 
 1. The parent records the canonical repository root, exact comparison base and head SHAs, and exact task/spec evidence. It makes sure no writer changes the checkout while review runs.
 2. Decide explicitly whether staged, unstaged, and untracked files are in scope. For included dirty state, record a bounded inventory and fingerprint; a commit SHA alone cannot pin it.
-3. Start each read-only child in an ordinary pane with `cwd` set to that checkout. Omit `worktree`.
+3. Start each read-only child in an ordinary pane with `cwd` set to that checkout. Omit `worktree`. With default grouped placement, the extension reuses that checkout's workspace and available space in this parent's owned Agents tabs, including a retained writer's root tab. It never moves the writer or creates another worktree. Separate parent processes do not adopt one another's tabs by label.
 4. Give every reviewer the same exact scope. Require it to report the repository root and `git rev-parse HEAD` before its review result.
 5. Before each dependent review wave and before reporting, recheck the head and dirty-state fingerprint. Drift makes prior evidence stale; review the new state again instead of mixing revisions.
 
@@ -205,7 +205,9 @@ This manual continuation is not watched by the original parent lifecycle. Do not
 
 ## Cleanup
 
-Cleanup is always explicit. First make sure commits, patches, or uncommitted files are no longer needed. Then remove the Herdr worktree workspace:
+Worktree and branch cleanup is always explicit. Ordinary temporary reviewer panes close after result delivery; Herdr removes their tab only if its last pane closes. The retained worktree root shell is excluded from automatic cleanup, and user-added panes are preserved. Persistent specialists retain their pane between tasks and follow the existing explicit stop semantics.
+
+First make sure commits, patches, or uncommitted files are no longer needed. Then remove the Herdr worktree workspace:
 
 ```bash
 herdr worktree remove --workspace <workspace-id>

--- a/pi-extension/subagents/herdr.ts
+++ b/pi-extension/subagents/herdr.ts
@@ -1,5 +1,7 @@
 import { execFile, execSync, execFileSync } from "node:child_process";
 import { promisify } from "node:util";
+import { realpathSync } from "node:fs";
+import { resolve, relative, isAbsolute, sep } from "node:path";
 import { isFiniteNumber, isPlainObject, isString } from "./type-guards.ts";
 
 const execFileAsync = promisify(execFile);
@@ -217,19 +219,157 @@ function buildWorktreeCreateArgs(
 	];
 }
 
-export function createHerdrSurface(name: string): string {
-	// Create a new tab per subagent so parallel spawns each get a full tab
-	// instead of ever-narrower splits of the parent pane. Target the current
-	// workspace explicitly because Herdr's implicit default may be another space.
+export function createHerdrSurface(name: string, cwd = process.cwd()): string {
+	// Legacy tab mode and BTW target the caller workspace explicitly; Herdr's
+	// implicit default may be another workspace.
 	const { workspace_id: workspaceId } = getHerdrCurrentPaneInfo();
-	const output = herdrExec(
-		buildTabCreateArgs(name, process.cwd(), workspaceId),
-	);
+	const output = herdrExec(buildTabCreateArgs(name, cwd, workspaceId));
 	const paneId = extractHerdrRootPaneId(output, "tab create");
 	try {
 		herdrExec(["pane", "rename", paneId, name]);
 	} catch {
 		// Optional — pane label is cosmetic.
+	}
+	return paneId;
+}
+
+interface OwnedAgentsTab {
+	workspaceId: string;
+	panes: Set<string>;
+	retainedPaneId?: string;
+}
+
+// In-memory ownership survives /reload, not process restart. Separate parent
+// processes never adopt tabs by label or share a capacity reservation.
+const agentsTabsKey = Symbol.for("pi-herdr-subagents:agents-tabs");
+// SAFETY: this extension alone writes this process-local symbol.
+const placementGlobal = globalThis as typeof globalThis & {
+	[agentsTabsKey]?: Map<string, OwnedAgentsTab>;
+};
+const agentsTabs = (placementGlobal[agentsTabsKey] ??= new Map<
+	string,
+	OwnedAgentsTab
+>());
+
+function canonicalPath(path: string): string {
+	try {
+		return realpathSync(path);
+	} catch {
+		return resolve(path);
+	}
+}
+
+function containsCwd(root: string, cwd: string): boolean {
+	const child = relative(root, cwd);
+	return (
+		child === "" ||
+		(child !== ".." && !child.startsWith(`..${sep}`) && !isAbsolute(child))
+	);
+}
+
+function placementPanes(): Array<{
+	pane_id: string;
+	tab_id: string;
+	workspace_id: string;
+}> {
+	const parsed = parseHerdrJson(herdrExec(["pane", "list"]));
+	const panes = parsed?.result?.panes;
+	if (
+		parsed?.result?.type !== "pane_list" ||
+		!Array.isArray(panes) ||
+		panes.some(
+			(pane) =>
+				!isString(pane?.pane_id) ||
+				!isString(pane?.tab_id) ||
+				!isString(pane?.workspace_id),
+		)
+	) {
+		throw new Error("Unexpected herdr pane list output for placement");
+	}
+	return panes;
+}
+
+export function createHerdrGroupedSurface(
+	name: string,
+	cwd: string,
+	maxPerTab: number,
+	direction: "right" | "down",
+): string {
+	const callerWorkspace = getHerdrCurrentPaneInfo().workspace_id;
+	const parsed = parseHerdrJson(herdrExec(["workspace", "list"]));
+	const workspaces = parsed?.result?.workspaces;
+	if (parsed?.result?.type !== "workspace_list" || !Array.isArray(workspaces)) {
+		throw new Error("Unexpected herdr workspace list output for placement");
+	}
+	const panes = placementPanes();
+	const target = canonicalPath(cwd);
+	let workspaceId = callerWorkspace;
+	let matchLength = -1;
+	for (const workspace of workspaces) {
+		if (!isString(workspace?.workspace_id))
+			throw new Error("Unexpected herdr workspace identity");
+		// Herdr exposes checkout ownership, but no stable non-Git workspace root.
+		// A shell's incidental cwd is not a workspace association.
+		const checkout = workspace.worktree?.checkout_path;
+		if (!isString(checkout)) continue;
+		const canonical = canonicalPath(checkout);
+		if (
+			containsCwd(canonical, target) &&
+			(canonical.length > matchLength ||
+				(canonical.length === matchLength &&
+					workspace.workspace_id === callerWorkspace))
+		) {
+			workspaceId = workspace.workspace_id;
+			matchLength = canonical.length;
+		}
+	}
+
+	// The entire inspect/create/record window is synchronous, before launch's
+	// first await. Overlapping launches in this parent cannot overbook a tab.
+	let paneId: string | undefined;
+	for (const [tabId, owned] of agentsTabs) {
+		if (owned.workspaceId !== workspaceId) continue;
+		const live = panes.filter(
+			(pane) => pane.tab_id === tabId && pane.workspace_id === workspaceId,
+		);
+		if (live.length === 0) {
+			agentsTabs.delete(tabId);
+			continue;
+		}
+		if (live.length >= maxPerTab) continue;
+		// The tab ID remains ours even when only user-added panes survive.
+		const anchor =
+			live.find((pane) => owned.panes.has(pane.pane_id)) ?? live[0];
+		paneId = extractHerdrPaneId(
+			herdrExec(buildPaneSplitArgs(anchor.pane_id, direction, cwd)),
+			"pane split",
+		);
+		owned.panes.add(paneId);
+		break;
+	}
+	if (!paneId) {
+		const count = [...agentsTabs.values()].filter(
+			(tab) => tab.workspaceId === workspaceId,
+		).length;
+		const label = count === 0 ? "Agents" : `Agents ${count + 1}`;
+		const output = herdrExec(buildTabCreateArgs(label, cwd, workspaceId));
+		paneId = extractHerdrRootPaneId(output, "tab create");
+		const tabId = parseHerdrJson(output)?.result?.tab?.tab_id;
+		if (!isString(tabId) || !tabId) {
+			// Only the explicitly returned pane is ours to roll back.
+			try {
+				herdrExec(["pane", "close", paneId]);
+			} catch {
+				/* preserve parse error */
+			}
+			throw new Error("Unexpected herdr tab create identity");
+		}
+		agentsTabs.set(tabId, { workspaceId, panes: new Set([paneId]) });
+	}
+	try {
+		herdrExec(["pane", "rename", paneId, name]);
+	} catch {
+		/* cosmetic */
 	}
 	return paneId;
 }
@@ -298,7 +438,9 @@ function parseHerdrPaneList(output: string, workspaceId: string): string[] {
 	) {
 		throw new Error("Unexpected herdr pane list output");
 	}
-	return parsed.result.panes
+	const panes: Array<{ workspace_id?: unknown; pane_id?: unknown }> =
+		parsed.result.panes;
+	return panes
 		.filter((pane) => pane.workspace_id === workspaceId)
 		.map((pane) => pane.pane_id)
 		.filter(isString);
@@ -327,6 +469,34 @@ function recoverHerdrWorktree(
 	};
 }
 
+function retainWorktreeTab(
+	worktree: HerdrWorktreeSurface,
+	output: string,
+): HerdrWorktreeSurface {
+	const returnedTabId = parseHerdrJson(output)?.result?.tab?.tab_id;
+	const tabId =
+		isString(returnedTabId) && returnedTabId
+			? returnedTabId
+			: placementPanes().find(
+					(pane) =>
+						pane.pane_id === worktree.paneId &&
+						pane.workspace_id === worktree.workspaceId,
+				)?.tab_id;
+	if (tabId) {
+		agentsTabs.set(tabId, {
+			workspaceId: worktree.workspaceId,
+			panes: new Set([worktree.paneId]),
+			retainedPaneId: worktree.paneId,
+		});
+		try {
+			herdrExec(["tab", "rename", tabId, "Agents"]);
+		} catch {
+			/* cosmetic */
+		}
+	}
+	return worktree;
+}
+
 export function createHerdrWorktree(
 	name: string,
 	cwd: string,
@@ -335,7 +505,7 @@ export function createHerdrWorktree(
 ): HerdrWorktreeSurface {
 	const output = herdrExec(buildWorktreeCreateArgs(name, cwd, branch, base));
 	try {
-		return extractHerdrWorktree(output);
+		return retainWorktreeTab(extractHerdrWorktree(output), output);
 	} catch (parseError) {
 		let recovered: HerdrWorktreeSurface | HerdrWorktreeInfo | undefined;
 		try {
@@ -343,7 +513,8 @@ export function createHerdrWorktree(
 		} catch {
 			throw parseError;
 		}
-		if (recovered?.workspaceId && "paneId" in recovered) return recovered;
+		if (recovered?.workspaceId && "paneId" in recovered)
+			return retainWorktreeTab(recovered, output);
 		if (recovered) {
 			throw new HerdrWorktreeCreateError(
 				`Herdr created branch ${branch}, but its workspace response was incomplete`,
@@ -357,11 +528,10 @@ export function createHerdrWorktree(
 export function createHerdrSurfaceSplit(
 	name: string,
 	direction: "right" | "down",
+	cwd = process.cwd(),
 ): string {
 	const parentPaneId = getHerdrParentPaneId();
-	const output = herdrExec(
-		buildPaneSplitArgs(parentPaneId, direction, process.cwd()),
-	);
+	const output = herdrExec(buildPaneSplitArgs(parentPaneId, direction, cwd));
 	const paneId = extractHerdrPaneId(output, "pane split");
 	try {
 		herdrExec(["pane", "rename", paneId, name]);
@@ -759,7 +929,14 @@ export function sendHerdrEscape(surface: string): void {
 }
 
 export function closeHerdrSurface(surface: string): void {
+	for (const owned of agentsTabs.values()) {
+		if (owned.retainedPaneId === surface) return;
+	}
+	// Herdr removes a tab when its last pane closes. Never close a whole tab:
+	// a user may have added a pane since our last snapshot.
 	herdrExec(["pane", "close", surface]);
+	// Keep tab ownership until placement observes that the tab is actually gone.
+	for (const owned of agentsTabs.values()) owned.panes.delete(surface);
 }
 
 export function renameHerdrTab(title: string): void {

--- a/pi-extension/subagents/herdr.ts
+++ b/pi-extension/subagents/herdr.ts
@@ -134,33 +134,25 @@ interface HerdrCurrentPaneInfo {
 }
 
 function getHerdrCurrentPaneInfo(): HerdrCurrentPaneInfo {
-	const paneId = process.env.HERDR_PANE_ID;
-	const tabId = process.env.HERDR_TAB_ID;
-	const workspaceId = process.env.HERDR_WORKSPACE_ID;
-
-	// Fall back to `herdr pane current` if any identity env var is missing —
-	// older herdr versions may not set all three.
-	if (!paneId || !tabId || !workspaceId) {
-		const output = herdrExec(buildCurrentPaneArgs());
-		const parsed = parseHerdrJson(output);
-		const pane = parsed?.result?.pane;
-		if (
-			!isString(pane?.pane_id) ||
-			!isString(pane?.tab_id) ||
-			!isString(pane?.workspace_id)
-		) {
-			throw new Error(
-				`Unexpected herdr pane current output: ${output.trim() || "(empty)"}`,
-			);
-		}
-		return {
-			pane_id: pane.pane_id,
-			tab_id: pane.tab_id,
-			workspace_id: pane.workspace_id,
-		};
+	// Inherited IDs go stale after a pane moves. Herdr resolves the calling
+	// terminal's original identity to its live pane, tab, and workspace.
+	const output = herdrExec(buildCurrentPaneArgs());
+	const parsed = parseHerdrJson(output);
+	const pane = parsed?.result?.pane;
+	if (
+		!isString(pane?.pane_id) ||
+		!isString(pane?.tab_id) ||
+		!isString(pane?.workspace_id)
+	) {
+		throw new Error(
+			`Unexpected herdr pane current output: ${output.trim() || "(empty)"}`,
+		);
 	}
-
-	return { pane_id: paneId, tab_id: tabId, workspace_id: workspaceId };
+	return {
+		pane_id: pane.pane_id,
+		tab_id: pane.tab_id,
+		workspace_id: pane.workspace_id,
+	};
 }
 
 function buildTabCreateArgs(

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -1028,10 +1028,9 @@ function resolveWorktreeLaunchWarning(
 		: undefined;
 }
 
-function finalizeSubagentSurface(
+function finalizeSubagentWorktree(
 	running: RunningSubagent,
 	state: "ready_for_review" | "failed" | "needs_help",
-	ignoreCloseError = false,
 ): WorktreeHandoff | undefined {
 	if (running.worktree) {
 		let handoff = captureWorktreeHandoff(running.worktree);
@@ -1051,12 +1050,17 @@ function finalizeSubagentSurface(
 		return handoff;
 	}
 
-	try {
-		closePane(running.surface);
-	} catch (error) {
-		if (!ignoreCloseError) throw error;
-	}
 	return undefined;
+}
+
+function closeCompletedPanes(panes: Iterable<string>): void {
+	for (const pane of panes) {
+		try {
+			closePane(pane);
+		} catch {
+			/* Result delivery remains authoritative. */
+		}
+	}
 }
 
 const statusConfig = loadStatusConfig();
@@ -2534,8 +2538,8 @@ async function launchSubagent(
 
 /**
  * Watch a launched subagent until it exits. Polls for completion, extracts
- * the summary from the session file, and closes ordinary panes. Worktree
- * workspaces are retained for parent review.
+ * the summary from the session file. Temporary panes close only after parent
+ * delivery; worktree workspaces remain retained for review.
  */
 function resolveSubagentRuntimePlans(
 	params: typeof SubagentParams.static,
@@ -2838,7 +2842,7 @@ async function watchSubagent(
 					: `Sub-agent exited with code ${result.exitCode}`;
 		}
 
-		const worktreeHandoff = finalizeSubagentSurface(
+		const worktreeHandoff = finalizeSubagentWorktree(
 			running,
 			result.ping
 				? "needs_help"
@@ -2870,7 +2874,7 @@ async function watchSubagent(
 		if (worktreeHandoff) watchResult.worktree = worktreeHandoff;
 		return watchResult;
 	} catch (err: any) {
-		const worktreeHandoff = finalizeSubagentSurface(running, "failed", true);
+		const worktreeHandoff = finalizeSubagentWorktree(running, "failed");
 		running.lifecycle = markFailed(
 			running.lifecycle,
 			signal.aborted ? "Subagent cancelled." : (err?.message ?? String(err)),
@@ -2926,6 +2930,7 @@ async function watchSubagentWithFallbacks(
 	parentThinking: ThinkingLevel,
 	plans: ResolvedRuntimePlan[],
 	signal: AbortSignal,
+	completedPanes: Set<string>,
 	initialLaunchFailures: ModelFailure[] = [],
 ): Promise<{ running: RunningSubagent; result: SubagentResult }> {
 	let running = initial;
@@ -2937,6 +2942,7 @@ async function watchSubagentWithFallbacks(
 
 	for (;;) {
 		const result = await watchSubagent(running, signal);
+		if (!running.worktree) completedPanes.add(running.surface);
 		const shouldRetry = shouldAdvanceToFallback(
 			result,
 			plans.length - nextPlan,
@@ -3236,6 +3242,10 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 				startWidgetRefresh();
 				startStatusRefresh(pi);
 
+				// Keep all temporary attempt panes until the final parent handoff.
+				const completedPanes = new Set<string>();
+				// Close after accepted delivery or explicit parent shutdown, not failed delivery.
+				let shouldCloseTemporaryPanes = false;
 				// Fire-and-forget: start watching in background
 				watchSubagentWithFallbacks(
 					running,
@@ -3245,6 +3255,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 					parentThinking,
 					runtimePlans,
 					watcherAbort.signal,
+					completedPanes,
 					initialLaunchFailures,
 				)
 					.then(({ running: completedRunning, result }) => {
@@ -3256,7 +3267,10 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 						if (completedRunning.stopTimeout)
 							clearTimeout(completedRunning.stopTimeout);
 						if (completedRunning.persistent) {
-							if (!shouldDeliverSubagentCompletion(completedRunning)) return;
+							if (!shouldDeliverSubagentCompletion(completedRunning)) {
+								shouldCloseTemporaryPanes = true;
+								return;
+							}
 							completedRunning.lifecycle = markDelivery(
 								completedRunning.lifecycle,
 								"delivered",
@@ -3286,11 +3300,14 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 							} else if (completedRunning.stopState !== "failed") {
 								notifyPersistentCrash(completedRunning, completionApi);
 							}
+							shouldCloseTemporaryPanes = true;
 							runningSubagents.delete(completedRunning.id);
 							updateWidget();
 							return;
 						}
 						if (!shouldDeliverSubagentCompletion(completedRunning)) {
+							// Explicit parent shutdown still releases temporary panes.
+							shouldCloseTemporaryPanes = true;
 							completedRunning.lifecycle = markDelivery(
 								completedRunning.lifecycle,
 								"suppressed",
@@ -3329,6 +3346,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 								},
 								{ triggerTurn: true, deliverAs: "steer" },
 							);
+							shouldCloseTemporaryPanes = true;
 							return;
 						}
 
@@ -3357,6 +3375,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 						if (completedRunning.runtimePlan)
 							resultDetails.runtimePlan = completedRunning.runtimePlan;
 						sendSubagentResult(completionApi, presentation, resultDetails);
+						shouldCloseTemporaryPanes = true;
 					})
 					.catch((err) => {
 						if (!shouldDeliverSubagentCompletion(running)) {
@@ -3373,6 +3392,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 								running,
 								selectCompletionApi(pi, runtime.pi),
 							);
+							shouldCloseTemporaryPanes = true;
 							return;
 						}
 						const errDetails: SubagentResultDetails = {
@@ -3392,6 +3412,10 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 							),
 							errDetails,
 						);
+						shouldCloseTemporaryPanes = true;
+					})
+					.finally(() => {
+						if (shouldCloseTemporaryPanes) closeCompletedPanes(completedPanes);
 					});
 
 				// Return immediately
@@ -3808,9 +3832,12 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 				const watcherAbort = new AbortController();
 				running.abortController = watcherAbort;
 
+				// Close after accepted delivery or explicit parent shutdown, not failed delivery.
+				let shouldCloseTemporaryPanes = false;
 				watchSubagent(running, watcherAbort.signal)
 					.then((result) => {
 						if (!shouldDeliverSubagentCompletion(running)) {
+							shouldCloseTemporaryPanes = true;
 							running.lifecycle = markDelivery(running.lifecycle, "suppressed");
 							runningSubagents.delete(running.id);
 							updateWidget();
@@ -3836,6 +3863,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 								},
 								{ triggerTurn: true, deliverAs: "steer" },
 							);
+							shouldCloseTemporaryPanes = true;
 							return;
 						}
 
@@ -3868,6 +3896,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 						if (running.runtimePlan)
 							resumeDetails.runtimePlan = running.runtimePlan;
 						sendSubagentResult(completionApi, presentation, resumeDetails);
+						shouldCloseTemporaryPanes = true;
 					})
 					.catch((err) => {
 						if (!shouldDeliverSubagentCompletion(running)) {
@@ -3888,6 +3917,11 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 							),
 							{ name, error: err?.message, sessionFile: params.sessionPath },
 						);
+						shouldCloseTemporaryPanes = true;
+					})
+					.finally(() => {
+						if (shouldCloseTemporaryPanes)
+							closeCompletedPanes([running.surface]);
 					});
 
 				return {

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -3223,7 +3223,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 					runtime.pi,
 				);
 				const {
-					running,
+					running: initialRunning,
 					index: initialPlanIndex,
 					launchFailures: initialLaunchFailures,
 				} = await launchSubagentWithFallbacks(
@@ -3232,6 +3232,8 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 					parentThinking,
 					runtimePlans,
 				);
+
+				let running = initialRunning;
 
 				// Create a separate AbortController for the watcher
 				// (the tool's signal completes when we return)
@@ -3259,11 +3261,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 					initialLaunchFailures,
 				)
 					.then(({ running: completedRunning, result }) => {
-						if (completedRunning.persistent)
-							drainPersistentTaskEvents(
-								completedRunning,
-								selectCompletionApi(pi, runtime.pi),
-							);
+						running = completedRunning;
 						if (completedRunning.stopTimeout)
 							clearTimeout(completedRunning.stopTimeout);
 						if (completedRunning.persistent) {
@@ -3271,6 +3269,10 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 								shouldCloseTemporaryPanes = true;
 								return;
 							}
+							drainPersistentTaskEvents(
+								completedRunning,
+								selectCompletionApi(pi, runtime.pi),
+							);
 							completedRunning.lifecycle = markDelivery(
 								completedRunning.lifecycle,
 								"delivered",

--- a/pi-extension/subagents/launch.ts
+++ b/pi-extension/subagents/launch.ts
@@ -14,9 +14,10 @@ import { createLifecycle, type SubagentLifecycle } from "./lifecycle.ts";
 import type { ResolvedRuntimePlan } from "./runtime-routing.ts";
 import { createSubagentPaneFactory, loadPaneConfig } from "./pane-config.ts";
 import { HerdrWorktreeCreateError } from "./herdr.ts";
-import type { JsonObject } from "./type-guards.ts";
+import { isNonEmptyString, type JsonObject } from "./type-guards.ts";
 import {
 	createWorktreeSessionFork,
+	getNewEntries,
 	readSubagentSessionPolicy,
 	seedSubagentSessionFile,
 	writeSubagentSessionPolicy,
@@ -24,6 +25,7 @@ import {
 import {
 	closePane,
 	createSubagentPane,
+	createGroupedSubagentPane,
 	createSubagentWorktree,
 	splitCurrentPane,
 	runScriptInPane,
@@ -160,7 +162,7 @@ export interface PiRunningChild {
 }
 
 export interface PiLaunchOperations {
-	createPane(name: string): string;
+	createPane(name: string, cwd?: string): string;
 	createWorktree(
 		name: string,
 		cwd: string,
@@ -189,6 +191,7 @@ const defaultOperations: PiLaunchOperations = {
 		paneConfig,
 		createSubagentPane,
 		splitCurrentPane,
+		createGroupedSubagentPane,
 	),
 	createWorktree: createSubagentWorktree,
 	waitForShellReady,
@@ -373,7 +376,9 @@ function prepareLaunchSurface(
 	const { request } = resolved;
 	if (!request.worktree) {
 		return {
-			surface: request.surface ?? operations.createPane(request.name),
+			surface:
+				request.surface ??
+				operations.createPane(request.name, resolved.sourceCwd),
 			targetCwd: resolved.sourceCwd,
 			effectiveAgentDir: resolved.localAgentDir ?? resolved.agentDir,
 			localAgentDir: resolved.localAgentDir,
@@ -750,7 +755,11 @@ async function launchResumedPiSubagent(
 		"artifacts",
 		request.parent.sessionId,
 	);
-	const surface = operations.createPane(request.name);
+	const header = getNewEntries(request.sessionFile, 0).find(
+		(entry) => entry.type === "session",
+	);
+	const cwd = isNonEmptyString(header?.cwd) ? header.cwd : process.cwd();
+	const surface = operations.createPane(request.name, cwd);
 	try {
 		await operations.waitForShellReady(surface);
 		const activityFile = getSubagentActivityFile(artifactDir, id);

--- a/pi-extension/subagents/pane-config.ts
+++ b/pi-extension/subagents/pane-config.ts
@@ -7,16 +7,27 @@ const PACKAGE_ROOT = join(dirname(fileURLToPath(import.meta.url)), "../..");
 const DEFAULT_PANE_CONFIG_PATH = join(PACKAGE_ROOT, "config.json");
 const PANE_CONFIG_EXAMPLE_PATH = join(PACKAGE_ROOT, "config.json.example");
 
-export type PaneMode = "tab" | "split";
+export type PaneMode = "grouped" | "tab" | "split";
 export type PaneDirection = "right" | "down";
 
 export interface PaneConfig {
 	mode: PaneMode;
 	direction: PaneDirection;
+	maxPerTab: number;
 }
 
-type PaneCreator = (name: string) => string;
-type SplitPaneCreator = (name: string, direction: PaneDirection) => string;
+type PaneCreator = (name: string, cwd?: string) => string;
+type SplitPaneCreator = (
+	name: string,
+	direction: PaneDirection,
+	cwd?: string,
+) => string;
+type GroupedPaneCreator = (
+	name: string,
+	cwd: string,
+	maxPerTab: number,
+	direction: PaneDirection,
+) => string;
 
 function invalidPaneConfig(source: string, message: string): never {
 	throw new Error(`Invalid subagent pane config in ${source}: ${message}`);
@@ -30,14 +41,14 @@ export function parsePaneConfig(
 		invalidPaneConfig(source, "root must be an object");
 	}
 	if (!Object.hasOwn(rawConfig, "panes")) {
-		return { mode: "tab", direction: "right" };
+		return { mode: "grouped", direction: "right", maxPerTab: 4 };
 	}
 	if (!isPlainObject(rawConfig.panes)) {
 		invalidPaneConfig(source, "panes must be an object");
 	}
 
 	const unsupportedKeys = Object.keys(rawConfig.panes).filter(
-		(key) => key !== "mode" && key !== "direction",
+		(key) => key !== "mode" && key !== "direction" && key !== "maxPerTab",
 	);
 	if (unsupportedKeys.length > 0) {
 		invalidPaneConfig(
@@ -46,13 +57,18 @@ export function parsePaneConfig(
 		);
 	}
 
-	let mode: PaneMode = "tab";
+	let mode: PaneMode = "grouped";
 	if (Object.hasOwn(rawConfig.panes, "mode")) {
 		if (
 			!isString(rawConfig.panes.mode) ||
-			(rawConfig.panes.mode !== "tab" && rawConfig.panes.mode !== "split")
+			(rawConfig.panes.mode !== "grouped" &&
+				rawConfig.panes.mode !== "tab" &&
+				rawConfig.panes.mode !== "split")
 		) {
-			invalidPaneConfig(source, 'panes.mode must be "tab" or "split"');
+			invalidPaneConfig(
+				source,
+				'panes.mode must be "grouped", "tab", or "split"',
+			);
 		}
 		mode = rawConfig.panes.mode;
 	}
@@ -69,7 +85,16 @@ export function parsePaneConfig(
 		direction = rawConfig.panes.direction;
 	}
 
-	return { mode, direction };
+	const maxPerTab = Object.hasOwn(rawConfig.panes, "maxPerTab")
+		? rawConfig.panes.maxPerTab
+		: 4;
+	if (!Number.isSafeInteger(maxPerTab) || maxPerTab < 1) {
+		invalidPaneConfig(
+			source,
+			"panes.maxPerTab must be a positive safe integer",
+		);
+	}
+	return { mode, direction, maxPerTab };
 }
 
 interface PaneConfigSource {
@@ -128,8 +153,16 @@ export function createSubagentPaneFactory(
 	config: PaneConfig,
 	createTab: PaneCreator,
 	createSplit: SplitPaneCreator,
+	createGrouped?: GroupedPaneCreator,
 ): PaneCreator {
+	if (config.mode === "grouped") {
+		return (name, cwd = process.cwd()) => {
+			if (!createGrouped)
+				throw new Error("Grouped pane creation is unavailable");
+			return createGrouped(name, cwd, config.maxPerTab, config.direction);
+		};
+	}
 	return config.mode === "split"
-		? (name) => createSplit(name, config.direction)
+		? (name, cwd) => createSplit(name, config.direction, cwd)
 		: createTab;
 }

--- a/pi-extension/subagents/terminal.ts
+++ b/pi-extension/subagents/terminal.ts
@@ -4,6 +4,7 @@ import { dirname, join } from "node:path";
 import {
 	closeHerdrSurface,
 	createHerdrSurface,
+	createHerdrGroupedSurface,
 	createHerdrSurfaceSplit,
 	createHerdrWorktree,
 	focusHerdrWorkspace,
@@ -49,9 +50,20 @@ export function shellQuote(value: string): string {
 }
 
 /** Create a new herdr tab and return its root pane ID. */
-export function createSubagentPane(name: string): PaneId {
+export function createSubagentPane(name: string, cwd?: string): PaneId {
 	assertTerminalAvailable();
-	return createHerdrSurface(name);
+	return createHerdrSurface(name, cwd);
+}
+
+/** Place a child in an owned Agents tab in the target checkout's workspace. */
+export function createGroupedSubagentPane(
+	name: string,
+	cwd: string,
+	maxPerTab: number,
+	direction: SplitDirection,
+): PaneId {
+	assertTerminalAvailable();
+	return createHerdrGroupedSurface(name, cwd, maxPerTab, direction);
 }
 
 /** Create a Git worktree in its own herdr workspace and return its root surface. */
@@ -69,9 +81,10 @@ export function createSubagentWorktree(
 export function splitCurrentPane(
 	name: string,
 	direction: SplitDirection,
+	cwd?: string,
 ): PaneId {
 	assertTerminalAvailable();
-	return createHerdrSurfaceSplit(name, direction);
+	return createHerdrSurfaceSplit(name, direction, cwd);
 }
 
 export function renameCurrentTab(title: string): void {

--- a/test/integration/harness.ts
+++ b/test/integration/harness.ts
@@ -163,8 +163,10 @@ export interface TestEnv {
 	backend: MuxBackend;
 	/** Dedicated workspace owned by this test environment. */
 	workspaceId: string;
-	/** Parent workspace restored after cleanup. */
+	/** Parent Herdr identity restored after cleanup. */
 	previousWorkspaceId: string | undefined;
+	previousPaneId: string | undefined;
+	previousTabId: string | undefined;
 	/** Agent configuration restored after cleanup. */
 	previousAgentDir: string | undefined;
 	/** Surfaces created directly by the harness. */
@@ -213,7 +215,7 @@ function writeTestProviderConfig(agentDir: string): void {
 	);
 }
 
-function createTestWorkspace(cwd: string): string {
+function createTestWorkspace(cwd: string) {
 	const output = execFileSync(
 		"herdr",
 		[
@@ -229,12 +231,23 @@ function createTestWorkspace(cwd: string): string {
 	);
 	const parsed = JSON.parse(output);
 	const workspaceId = parsed.result?.workspace?.workspace_id;
-	if (!isNonEmptyString(workspaceId)) {
+	const paneId = parsed.result?.root_pane?.pane_id;
+	const tabId = parsed.result?.root_pane?.tab_id;
+	if (
+		!isNonEmptyString(workspaceId) ||
+		!isNonEmptyString(paneId) ||
+		!isNonEmptyString(tabId)
+	) {
 		throw new Error(
 			`Unexpected herdr workspace create output: ${output.trim() || "(empty)"}`,
 		);
 	}
-	return workspaceId;
+	return { workspaceId, paneId, tabId };
+}
+
+function restoreEnv(name: string, value: string | undefined): void {
+	if (value === undefined) delete process.env[name];
+	else process.env[name] = value;
 }
 
 /**
@@ -246,51 +259,77 @@ export function createTestEnv(backend: MuxBackend): TestEnv {
 	const agentsDir = join(dir, ".pi", "agents");
 	const agentDir = join(dir, ".pi", "agent");
 	const previousWorkspaceId = process.env.HERDR_WORKSPACE_ID;
+	const previousPaneId = process.env.HERDR_PANE_ID;
+	const previousTabId = process.env.HERDR_TAB_ID;
 	const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
 	if (!previousWorkspaceId)
 		throw new Error("HERDR_WORKSPACE_ID is required for integration tests");
-	const workspaceId = createTestWorkspace(dir);
-	// Herdr creates subagent tabs in the workspace identified by this env var.
-	// Point the harness at its dedicated workspace without changing the parent's pane.
+	const { workspaceId, paneId, tabId } = createTestWorkspace(dir);
+	// Use the returned root identity so headless launches target this fixture,
+	// never the outer user's pane. These snapshots also support nested fixtures.
 	process.env.HERDR_WORKSPACE_ID = workspaceId;
-	mkdirSync(agentsDir, { recursive: true });
-	if (USE_TEST_PROVIDER) {
-		// Nested coordinator children use automatic extension discovery. Point the
-		// isolated agent home at this worktree instead of an installed snapshot.
-		mkdirSync(join(agentDir, "extensions"), { recursive: true });
-		writeFileSync(
-			join(agentDir, "extensions", "subagents.ts"),
-			`export { default } from ${JSON.stringify(EXTENSION_SOURCE)};\n`,
-			"utf8",
-		);
-		writeTestProviderConfig(agentDir);
-		process.env.PI_CODING_AGENT_DIR = agentDir;
-	}
+	process.env.HERDR_PANE_ID = paneId;
+	process.env.HERDR_TAB_ID = tabId;
+	try {
+		mkdirSync(agentsDir, { recursive: true });
+		if (USE_TEST_PROVIDER) {
+			// Nested coordinator children use automatic extension discovery. Point the
+			// isolated agent home at this worktree instead of an installed snapshot.
+			mkdirSync(join(agentDir, "extensions"), { recursive: true });
+			writeFileSync(
+				join(agentDir, "extensions", "subagents.ts"),
+				`export { default } from ${JSON.stringify(EXTENSION_SOURCE)};\n`,
+				"utf8",
+			);
+			writeTestProviderConfig(agentDir);
+			process.env.PI_CODING_AGENT_DIR = agentDir;
+		}
 
-	// Copy test agent definitions into the project-local agents dir and pin
-	// every child subagent to the same model selected for the outer Pi sessions.
-	// Without this rewrite, fixture frontmatter can silently bypass PI_TEST_MODEL.
-	if (existsSync(TEST_AGENTS_SRC)) {
-		for (const file of readdirSync(TEST_AGENTS_SRC)) {
-			if (file.endsWith(".md")) {
-				const source = readFileSync(join(TEST_AGENTS_SRC, file), "utf8");
-				const configured = /^model:\s*.*$/m.test(source)
-					? source.replace(/^model:\s*.*$/m, `model: ${TEST_MODEL}`)
-					: source.replace(/^---\n/, `---\nmodel: ${TEST_MODEL}\n`);
-				writeFileSync(join(agentsDir, file), configured, "utf8");
+		// Copy test agent definitions into the project-local agents dir and pin
+		// every child subagent to the same model selected for the outer Pi sessions.
+		// Without this rewrite, fixture frontmatter can silently bypass PI_TEST_MODEL.
+		if (existsSync(TEST_AGENTS_SRC)) {
+			for (const file of readdirSync(TEST_AGENTS_SRC)) {
+				if (file.endsWith(".md")) {
+					const source = readFileSync(join(TEST_AGENTS_SRC, file), "utf8");
+					const configured = /^model:\s*.*$/m.test(source)
+						? source.replace(/^model:\s*.*$/m, `model: ${TEST_MODEL}`)
+						: source.replace(/^---\n/, `---\nmodel: ${TEST_MODEL}\n`);
+					writeFileSync(join(agentsDir, file), configured, "utf8");
+				}
 			}
 		}
-	}
 
-	return {
-		dir,
-		backend,
-		workspaceId,
-		previousWorkspaceId,
-		previousAgentDir,
-		surfaces: [],
-		tempFiles: [],
-	};
+		return {
+			dir,
+			backend,
+			workspaceId,
+			previousWorkspaceId,
+			previousPaneId,
+			previousTabId,
+			previousAgentDir,
+			surfaces: [],
+			tempFiles: [],
+		};
+	} catch (error) {
+		try {
+			execFileSync("herdr", ["workspace", "close", workspaceId], {
+				encoding: "utf8",
+			});
+		} catch {
+			// Best effort; preserve the original setup error.
+		}
+		restoreEnv("HERDR_WORKSPACE_ID", previousWorkspaceId);
+		restoreEnv("HERDR_PANE_ID", previousPaneId);
+		restoreEnv("HERDR_TAB_ID", previousTabId);
+		restoreEnv("PI_CODING_AGENT_DIR", previousAgentDir);
+		try {
+			rmSync(dir, { recursive: true, force: true });
+		} catch {
+			// Best effort after closing the owned workspace.
+		}
+		throw error;
+	}
 }
 
 /**
@@ -313,16 +352,10 @@ export function cleanupTestEnv(env: TestEnv): void {
 	} catch {
 		// Best effort; the workspace can already be closed.
 	}
-	if (env.previousWorkspaceId) {
-		process.env.HERDR_WORKSPACE_ID = env.previousWorkspaceId;
-	} else {
-		delete process.env.HERDR_WORKSPACE_ID;
-	}
-	if (env.previousAgentDir) {
-		process.env.PI_CODING_AGENT_DIR = env.previousAgentDir;
-	} else {
-		delete process.env.PI_CODING_AGENT_DIR;
-	}
+	restoreEnv("HERDR_WORKSPACE_ID", env.previousWorkspaceId);
+	restoreEnv("HERDR_PANE_ID", env.previousPaneId);
+	restoreEnv("HERDR_TAB_ID", env.previousTabId);
+	restoreEnv("PI_CODING_AGENT_DIR", env.previousAgentDir);
 	for (const file of env.tempFiles) {
 		try {
 			unlinkSync(file);

--- a/test/integration/placement.test.ts
+++ b/test/integration/placement.test.ts
@@ -15,6 +15,7 @@ import {
 	createSubagentWorktree,
 	waitForShellReady,
 	runScriptInPane,
+	shellQuote,
 } from "../../pi-extension/subagents/terminal.ts";
 import {
 	createSubagentPaneFactory,
@@ -95,6 +96,102 @@ for (const backend of getAvailableBackends()) {
 				},
 			};
 		}
+
+		it("places an unmatched child in the live caller workspace after its parent pane moves", async () => {
+			const identities = (workspaceId: string) =>
+				panes(workspaceId).map(({ pane_id, tab_id, cwd }) => ({
+					pane_id,
+					tab_id,
+					cwd,
+				}));
+			const sourceBaseline = identities(env.workspaceId);
+			const destination = createTestEnv(backend);
+			try {
+				const focus = getFocusedSurface(backend);
+				const destinationBaseline = identities(destination.workspaceId);
+				const parent = JSON.parse(
+					execFileSync(
+						"herdr",
+						[
+							"tab",
+							"create",
+							"--workspace",
+							env.workspaceId,
+							"--cwd",
+							env.dir,
+							"--label",
+							"moved-parent",
+							"--no-focus",
+						],
+						{ encoding: "utf8" },
+					),
+				).result.root_pane;
+				const script = join(env.dir, "moved-parent.mjs");
+				const report = join(env.dir, "moved-parent.json");
+				const launchUrl = new URL(
+					"../../pi-extension/subagents/launch.ts",
+					import.meta.url,
+				).href;
+				// Execute inside the original terminal: do not manufacture inherited
+				// Herdr identity in the runner. The same process moves, then launches.
+				writeFileSync(
+					script,
+					`
+import { execFileSync } from "node:child_process";
+import { writeFileSync } from "node:fs";
+import { launchPiSubagent } from ${JSON.stringify(launchUrl)};
+const cli = (...args) => JSON.parse(execFileSync("herdr", args, { encoding: "utf8" })).result;
+const result = {};
+try {
+  result.inherited = { pane_id: process.env.HERDR_PANE_ID, tab_id: process.env.HERDR_TAB_ID, workspace_id: process.env.HERDR_WORKSPACE_ID };
+  result.before = cli("pane", "current", "--current").pane;
+  result.move = cli("pane", "move", result.before.pane_id, "--new-tab", "--workspace", ${JSON.stringify(destination.workspaceId)}, "--no-focus").move_result;
+  result.after = cli("pane", "current", "--current").pane;
+  result.child = await launchPiSubagent(${JSON.stringify(request(1))});
+} catch (error) {
+  result.error = String(error.stack ?? error);
+}
+writeFileSync(${JSON.stringify(report)}, JSON.stringify(result));
+`,
+				);
+				await waitForShellReady(parent.pane_id);
+				runScriptInPane(
+					parent.pane_id,
+					`PI_CODING_AGENT_DIR=${shellQuote(join(env.dir, ".pi", "agent"))} ${shellQuote(process.execPath)} --experimental-strip-types ${shellQuote(script)}`,
+					{ scriptPath: join(env.dir, "moved-parent.sh") },
+				);
+				const result = JSON.parse(await waitForFile(report, 60_000));
+				console.log("native moved-parent evidence", JSON.stringify(result));
+				assert.equal(result.error, undefined);
+				assert.equal(result.inherited.pane_id, parent.pane_id);
+				assert.equal(result.inherited.workspace_id, env.workspaceId);
+				assert.equal(result.before.pane_id, parent.pane_id);
+				assert.equal(result.after.workspace_id, destination.workspaceId);
+				assert.equal(result.after.pane_id, result.move.pane.pane_id);
+				assert.equal(result.after.terminal_id, result.before.terminal_id);
+				assert.notEqual(result.after.pane_id, result.inherited.pane_id);
+				assert.notEqual(result.after.tab_id, result.inherited.tab_id);
+				assert.equal(getFocusedSurface(backend), focus);
+				assert.ok(
+					panes(destination.workspaceId).some(
+						(pane) =>
+							pane.pane_id === result.child.surface && pane.cwd === env.dir,
+					),
+					"unmatched non-Git cwd must use the parent's live workspace, not inherited workspace",
+				);
+				await waitForFile(`${result.child.sessionFile}.exit`, 60_000);
+				closePane(result.child.surface);
+				closePane(result.after.pane_id);
+				assert.deepEqual(identities(env.workspaceId), sourceBaseline);
+				assert.deepEqual(
+					identities(destination.workspaceId),
+					destinationBaseline,
+				);
+				assert.equal(getFocusedSurface(backend), focus);
+			} finally {
+				cleanupTestEnv(destination);
+			}
+		});
 
 		it("fills four panes before overflow, counts user panes, and reuses their tab after all children close", async () => {
 			const focus = getFocusedSurface(backend);
@@ -271,13 +368,24 @@ for (const backend of getAvailableBackends()) {
 					"pi-integration/fallback-primary,pi-integration/fallback-secondary",
 				type: "subagent_result",
 			},
+			{
+				name: "fallback rejected delivery",
+				task: "Return exactly DELIVERED",
+				model:
+					"pi-integration/fallback-primary,pi-integration/fallback-secondary",
+				type: "subagent_result",
+			},
 		])
 			it(`${scenario.name}: closes panes only after accepted delivery`, async () => {
 				const previousId = process.env.PI_SUBAGENT_ID;
 				delete process.env.PI_SUBAGENT_ID;
 				const tools = new Map<string, any>();
 				const handlers = new Map<string, Function>();
-				const deliveries: Array<{ type: string; panes: string[] }> = [];
+				const deliveries: Array<{
+					type: string;
+					panes: string[];
+					details: any;
+				}> = [];
 				const api: Partial<ExtensionAPI> = {
 					events: createEventBus(),
 					on: (name: string, handler: Function) => handlers.set(name, handler),
@@ -287,12 +395,17 @@ for (const backend of getAvailableBackends()) {
 					registerMessageRenderer() {},
 					getThinkingLevel: () => "off",
 					getAllTools: () => [],
-					sendMessage: (message: { customType: string }) => {
+					sendMessage: (message: { customType: string; details?: any }) => {
 						deliveries.push({
 							type: message.customType,
 							panes: panes(env.workspaceId).map((pane) => pane.pane_id),
+							details: message.details,
 						});
-						if (scenario.name === "rejected delivery")
+						if (
+							scenario.name === "rejected delivery" ||
+							(scenario.name === "fallback rejected delivery" &&
+								deliveries.length === 1)
+						)
 							throw new Error("injected parent delivery failure");
 					},
 				};
@@ -360,6 +473,34 @@ for (const backend of getAvailableBackends()) {
 						delivery.panes.includes(child.pane_id),
 						"the owned pane must exist at parent result delivery",
 					);
+					if (scenario.name === "fallback rejected delivery") {
+						assert.equal(delivery.details.exitCode, 0);
+						assert.notEqual(
+							delivery.details.sessionFile,
+							started.details.sessionFile,
+							"the rejected result belongs to the successful fallback session",
+						);
+						assert.deepEqual(delivery.details.fallbackAttempts, [
+							"pi-integration/fallback-primary",
+							"pi-integration/fallback-secondary",
+						]);
+						assert.match(
+							delivery.details.fallbackFailures[0].error,
+							/deterministic fallback provider failure/,
+						);
+						assert.equal(
+							deliveries.length,
+							1,
+							"rejected fallback delivery must not send an error for the first attempt",
+						);
+						assert.equal(delivery.panes.length, baseline.size + 2);
+						assert.deepEqual(
+							panes(env.workspaceId).map((pane) => pane.pane_id),
+							delivery.panes,
+							"both attempt panes must remain until explicit cleanup",
+						);
+						return;
+					}
 					if (scenario.name === "rejected delivery") {
 						assert.ok(
 							panes(env.workspaceId).some(
@@ -420,6 +561,181 @@ for (const backend of getAvailableBackends()) {
 					}
 				} finally {
 					await handlers.get("session_shutdown")?.({ reason: "quit" }, ctx);
+					if (previousId === undefined) delete process.env.PI_SUBAGENT_ID;
+					else process.env.PI_SUBAGENT_ID = previousId;
+				}
+			});
+
+		for (const managed of [false, true])
+			it(`parent quit after rejected persistent task delivery: ${managed ? "retains managed root" : "closes ordinary pane and process"}`, async () => {
+				const previousId = process.env.PI_SUBAGENT_ID;
+				delete process.env.PI_SUBAGENT_ID;
+				const tools = new Map<string, any>();
+				const handlers = new Map<string, Function>();
+				let childSurface: string;
+				let childPid: number | undefined;
+				let rejectedDeliveries = 0;
+				let shutdown: Promise<void> | undefined;
+				let worktree: { workspaceId: string; path: string } | undefined;
+				const api: Partial<ExtensionAPI> = {
+					events: createEventBus(),
+					on: (name: string, handler: Function) => handlers.set(name, handler),
+					registerTool: (tool: any) => tools.set(tool.name, tool),
+					registerCommand() {},
+					registerShortcut() {},
+					registerMessageRenderer() {},
+					getThinkingLevel: () => "off",
+					getAllTools: () => [],
+					sendMessage: (message: { customType: string }) => {
+						assert.equal(message.customType, "subagent_result");
+						if (rejectedDeliveries++ === 0) {
+							const info = JSON.parse(
+								execFileSync(
+									"herdr",
+									["pane", "process-info", "--pane", childSurface],
+									{
+										encoding: "utf8",
+									},
+								),
+							).result.process_info;
+							childPid = info.foreground_processes.find(
+								(child: { name: string }) => child.name === "pi",
+							)?.pid;
+							// Quit while a real task event remains undelivered. A later
+							// drain would hit the same unavailable parent SDK binding.
+							shutdown = handlers.get("session_shutdown")!(
+								{ reason: "quit" },
+								ctx,
+							);
+						}
+						throw new Error("parent delivery unavailable during quit");
+					},
+				};
+				const sessionManager = SessionManager.create(env.dir, env.dir);
+				sessionManager.appendMessage({
+					role: "user",
+					content: "fixture",
+					timestamp: Date.now(),
+				});
+				const model = {
+					provider: "pi-integration",
+					id: "test",
+					reasoning: true,
+				};
+				const ctx = {
+					cwd: env.dir,
+					hasUI: false,
+					sessionManager,
+					model,
+					modelRegistry: {
+						find: () => model,
+						getAvailable: () => [model],
+						hasConfiguredAuth: () => true,
+					},
+				};
+				try {
+					if (managed) {
+						execFileSync("git", ["init", "-q", "-b", "main"], { cwd: env.dir });
+						execFileSync(
+							"git",
+							[
+								"-c",
+								"user.name=Test",
+								"-c",
+								"user.email=test@example.com",
+								"-c",
+								"commit.gpgsign=false",
+								"commit",
+								"--allow-empty",
+								"-qm",
+								"fixture",
+							],
+							{ cwd: env.dir },
+						);
+					}
+					// SAFETY: headless host implements the public SDK methods used here.
+					subagentsExtension(api as ExtensionAPI);
+					handlers.get("session_start")?.({}, ctx);
+					const baseline = panes(env.workspaceId).map((pane) => pane.pane_id);
+					type PersistentQuitParams = {
+						name: string;
+						task: string;
+						model: string;
+						tools: string;
+						persistent: boolean;
+						worktree?: { branch: string };
+					};
+					const params: PersistentQuitParams = {
+						name: "persistent-quit",
+						task: "Return exactly TASK_COMPLETE",
+						model: TEST_MODEL,
+						tools: "read",
+						persistent: true,
+					};
+					if (managed)
+						params.worktree = { branch: "placement-persistent-quit" };
+					const started = await tools
+						.get("subagent")
+						.execute("persistent-quit", params, undefined, undefined, ctx);
+					assert.equal(started.details.status, "started");
+					worktree = started.details.worktree;
+					childSurface = panes(worktree?.workspaceId ?? env.workspaceId).find(
+						(pane) => !baseline.includes(pane.pane_id),
+					)!.pane_id;
+					const deadline = Date.now() + 60_000;
+					while (!shutdown && Date.now() < deadline) await sleep(50);
+					assert.ok(shutdown, "a real task result must trigger parent quit");
+					await shutdown;
+					assert.ok(
+						childPid,
+						"the specialist must still be a live Pi process at quit",
+					);
+					if (managed) {
+						assert.deepEqual(
+							panes(worktree!.workspaceId).map((pane) => pane.pane_id),
+							[childSurface],
+						);
+					} else {
+						const closeDeadline = Date.now() + 10_000;
+						while (
+							panes(env.workspaceId).some(
+								(pane) => pane.pane_id === childSurface,
+							) &&
+							Date.now() < closeDeadline
+						)
+							await sleep(50);
+						assert.deepEqual(
+							panes(env.workspaceId).map((pane) => pane.pane_id),
+							baseline,
+							"explicit quit must close the ordinary pane despite failed event delivery",
+						);
+						while (Date.now() < closeDeadline) {
+							try {
+								process.kill(childPid, 0);
+							} catch {
+								break;
+							}
+							await sleep(50);
+						}
+						assert.throws(() => process.kill(childPid!, 0), { code: "ESRCH" });
+					}
+					assert.equal(
+						rejectedDeliveries,
+						1,
+						"quit must not drain pending task events again",
+					);
+				} finally {
+					await handlers.get("session_shutdown")?.({ reason: "quit" }, ctx);
+					if (worktree) {
+						execFileSync("herdr", [
+							"worktree",
+							"remove",
+							"--workspace",
+							worktree.workspaceId,
+							"--force",
+						]);
+						rmdirSync(dirname(worktree.path));
+					}
 					if (previousId === undefined) delete process.env.PI_SUBAGENT_ID;
 					else process.env.PI_SUBAGENT_ID = previousId;
 				}

--- a/test/integration/placement.test.ts
+++ b/test/integration/placement.test.ts
@@ -1,0 +1,565 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, rmdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import {
+	launchPiSubagent,
+	type FreshPiLaunchRequest,
+} from "../../pi-extension/subagents/launch.ts";
+import {
+	closePane,
+	createSubagentPane,
+	splitCurrentPane,
+	createGroupedSubagentPane,
+	createSubagentWorktree,
+	waitForShellReady,
+	runScriptInPane,
+} from "../../pi-extension/subagents/terminal.ts";
+import {
+	createSubagentPaneFactory,
+	loadPaneConfig,
+} from "../../pi-extension/subagents/pane-config.ts";
+import subagentsExtension from "../../pi-extension/subagents/index.ts";
+import {
+	createEventBus,
+	SessionManager,
+	type ExtensionAPI,
+} from "@earendil-works/pi-coding-agent";
+import {
+	createTestEnv,
+	cleanupTestEnv,
+	getAvailableBackends,
+	getFocusedSurface,
+	sleep,
+	waitForFile,
+	TEST_MODEL,
+	type TestEnv,
+} from "./harness.ts";
+
+function panes(
+	workspaceId: string,
+): Array<{ pane_id: string; tab_id: string; cwd: string }> {
+	return JSON.parse(
+		execFileSync("herdr", ["pane", "list", "--workspace", workspaceId], {
+			encoding: "utf8",
+		}),
+	).result.panes;
+}
+
+for (const backend of getAvailableBackends()) {
+	describe("grouped public launch placement", { timeout: 120_000 }, () => {
+		let env: TestEnv;
+		beforeEach(() => {
+			env = createTestEnv(backend);
+		});
+		afterEach(() => {
+			cleanupTestEnv(env);
+		});
+
+		function request(index: number): FreshPiLaunchRequest {
+			const sessionFile = join(env.dir, "parent.jsonl");
+			writeFileSync(
+				sessionFile,
+				JSON.stringify({
+					type: "session",
+					version: 3,
+					id: "parent",
+					cwd: env.dir,
+				}) + "\n",
+			);
+			return {
+				kind: "fresh",
+				name: `placement-${index}`,
+				task: "Reply with only PLACEMENT_COMPLETE.",
+				parent: {
+					cwd: env.dir,
+					sessionFile,
+					sessionId: "parent",
+					sessionDir: env.dir,
+				},
+				runtimePlan: {
+					provider: "pi-integration",
+					modelId: "test",
+					model: TEST_MODEL,
+					thinking: "off",
+					modelSource: "request",
+					thinkingSource: "request",
+				},
+				behavior: {
+					tools: "read",
+					deniedTools: ["subagent"],
+					autoExit: true,
+					interactive: false,
+					sessionMode: "standalone",
+				},
+			};
+		}
+
+		it("fills four panes before overflow, counts user panes, and reuses their tab after all children close", async () => {
+			const focus = getFocusedSurface(backend);
+			const baseline = panes(env.workspaceId);
+			const userTab = JSON.parse(
+				execFileSync(
+					"herdr",
+					[
+						"tab",
+						"create",
+						"--workspace",
+						env.workspaceId,
+						"--cwd",
+						env.dir,
+						"--label",
+						"Agents",
+						"--no-focus",
+					],
+					{ encoding: "utf8" },
+				),
+			).result;
+			const children = await Promise.all(
+				Array.from({ length: 5 }, (_, index) =>
+					launchPiSubagent(request(index)),
+				),
+			);
+			const snapshot = panes(env.workspaceId);
+			const childTabs = children.map(
+				(child) =>
+					snapshot.find((pane) => pane.pane_id === child.surface)!.tab_id,
+			);
+			assert.equal(new Set(childTabs.slice(0, 4)).size, 1);
+			assert.notEqual(childTabs[4], childTabs[0]);
+			assert.notEqual(
+				childTabs[0],
+				userTab.tab.tab_id,
+				"a matching display label never grants ownership",
+			);
+			assert.equal(getFocusedSurface(backend), focus);
+
+			closePane(children[0].surface);
+			const userPane = JSON.parse(
+				execFileSync(
+					"herdr",
+					[
+						"pane",
+						"split",
+						children[1].surface,
+						"--direction",
+						"down",
+						"--cwd",
+						env.dir,
+						"--no-focus",
+					],
+					{ encoding: "utf8" },
+				),
+			).result.pane.pane_id;
+			const sixth = await launchPiSubagent(request(6));
+			assert.equal(
+				panes(env.workspaceId).find((pane) => pane.pane_id === sixth.surface)!
+					.tab_id,
+				childTabs[4],
+				"actual user panes consume capacity",
+			);
+			for (const child of [...children.slice(1), sixth])
+				closePane(child.surface);
+			const remaining = panes(env.workspaceId);
+			assert.deepEqual(
+				new Set(remaining.map((pane) => pane.pane_id)),
+				new Set([
+					...baseline.map((pane) => pane.pane_id),
+					userTab.root_pane.pane_id,
+					userPane,
+				]),
+			);
+			const tabs = JSON.parse(
+				execFileSync("herdr", ["tab", "list", "--workspace", env.workspaceId], {
+					encoding: "utf8",
+				}),
+			).result.tabs;
+			assert.equal(
+				tabs.some((tab: { tab_id: string }) => tab.tab_id === childTabs[4]),
+				false,
+				"empty owned tab disappears",
+			);
+			const next = await launchPiSubagent(request(7));
+			assert.equal(
+				panes(env.workspaceId).find((pane) => pane.pane_id === next.surface)
+					?.tab_id,
+				childTabs[0],
+				"the ID-owned Agents tab remains reusable with only a user pane",
+			);
+			closePane(next.surface);
+			assert.deepEqual(
+				new Set(panes(env.workspaceId).map((pane) => pane.pane_id)),
+				new Set(remaining.map((pane) => pane.pane_id)),
+				"cleanup preserves the user's existing shell identity",
+			);
+		});
+
+		it("respects configured capacity during overlapping launches and rolls back only a failed child", async () => {
+			const configPath = join(env.dir, "placement-config.json");
+			writeFileSync(configPath, JSON.stringify({ panes: { maxPerTab: 2 } }));
+			const operations = {
+				createPane: createSubagentPaneFactory(
+					loadPaneConfig(configPath),
+					createSubagentPane,
+					splitCurrentPane,
+					createGroupedSubagentPane,
+				),
+				createWorktree: createSubagentWorktree,
+				waitForShellReady,
+				runScript: runScriptInPane,
+				closePane,
+			};
+			const children = await Promise.all(
+				Array.from({ length: 5 }, (_, index) =>
+					launchPiSubagent(request(index), operations),
+				),
+			);
+			const snapshot = panes(env.workspaceId);
+			const counts = new Map<string, number>();
+			for (const child of children) {
+				const tab = snapshot.find(
+					(pane) => pane.pane_id === child.surface,
+				)!.tab_id;
+				counts.set(tab, (counts.get(tab) ?? 0) + 1);
+			}
+			assert.deepEqual([...counts.values()], [2, 2, 1]);
+			await assert.rejects(
+				launchPiSubagent(request(6), {
+					...operations,
+					runScript: () => {
+						throw new Error("injected command delivery failure");
+					},
+				}),
+				/injected command delivery failure/,
+			);
+			assert.deepEqual(
+				panes(env.workspaceId).map((pane) => pane.pane_id),
+				snapshot.map((pane) => pane.pane_id),
+			);
+		});
+
+		for (const scenario of [
+			{
+				name: "ordinary",
+				task: "Return exactly DELIVERED",
+				model: TEST_MODEL,
+				type: "subagent_result",
+			},
+			{
+				name: "rejected delivery",
+				task: "Return exactly DELIVERED",
+				model: TEST_MODEL,
+				type: "subagent_result",
+			},
+			{
+				name: "help",
+				task: "ONLY call caller_ping",
+				model: TEST_MODEL,
+				type: "subagent_ping",
+			},
+			{
+				name: "provider error",
+				task: "Return exactly DELIVERED",
+				model: "pi-integration/account-rejected",
+				type: "subagent_result",
+			},
+			{
+				name: "fallback",
+				task: "Return exactly DELIVERED",
+				model:
+					"pi-integration/fallback-primary,pi-integration/fallback-secondary",
+				type: "subagent_result",
+			},
+		])
+			it(`${scenario.name}: closes panes only after accepted delivery`, async () => {
+				const previousId = process.env.PI_SUBAGENT_ID;
+				delete process.env.PI_SUBAGENT_ID;
+				const tools = new Map<string, any>();
+				const handlers = new Map<string, Function>();
+				const deliveries: Array<{ type: string; panes: string[] }> = [];
+				const api: Partial<ExtensionAPI> = {
+					events: createEventBus(),
+					on: (name: string, handler: Function) => handlers.set(name, handler),
+					registerTool: (tool: any) => tools.set(tool.name, tool),
+					registerCommand() {},
+					registerShortcut() {},
+					registerMessageRenderer() {},
+					getThinkingLevel: () => "off",
+					getAllTools: () => [],
+					sendMessage: (message: { customType: string }) => {
+						deliveries.push({
+							type: message.customType,
+							panes: panes(env.workspaceId).map((pane) => pane.pane_id),
+						});
+						if (scenario.name === "rejected delivery")
+							throw new Error("injected parent delivery failure");
+					},
+				};
+				const sessionManager = SessionManager.create(env.dir, env.dir);
+				sessionManager.appendMessage({
+					role: "user",
+					content: "fixture",
+					timestamp: Date.now(),
+				});
+				const model = {
+					provider: "pi-integration",
+					id: "test",
+					reasoning: true,
+				};
+				// SAFETY: no UI methods are used by this headless public-tool host.
+				const ctx = {
+					cwd: env.dir,
+					hasUI: false,
+					sessionManager,
+					model,
+					modelRegistry: {
+						find: (provider: string, id: string) => ({
+							...model,
+							provider,
+							id,
+						}),
+						getAvailable: () => [model],
+						hasConfiguredAuth: () => true,
+					},
+				};
+				try {
+					// SAFETY: this host implements the public SDK methods exercised by these tools.
+					subagentsExtension(api as ExtensionAPI);
+					handlers.get("session_start")?.({}, ctx);
+					const baseline = new Set(
+						panes(env.workspaceId).map((pane) => pane.pane_id),
+					);
+					const started = await tools.get("subagent").execute(
+						"call",
+						{
+							name: "delivery-order",
+							task: scenario.task,
+							model: scenario.model,
+							tools: "read",
+						},
+						undefined,
+						undefined,
+						ctx,
+					);
+					const child = panes(env.workspaceId).find(
+						(pane) => !baseline.has(pane.pane_id),
+					);
+					assert.ok(child);
+					const deadline = Date.now() + 60_000;
+					while (
+						!deliveries.some((entry) => entry.type === scenario.type) &&
+						Date.now() < deadline
+					)
+						await sleep(50);
+					const delivery = deliveries.find(
+						(entry) => entry.type === scenario.type,
+					);
+					assert.ok(delivery, "result must reach the parent");
+					assert.ok(
+						delivery.panes.includes(child.pane_id),
+						"the owned pane must exist at parent result delivery",
+					);
+					if (scenario.name === "rejected delivery") {
+						assert.ok(
+							panes(env.workspaceId).some(
+								(pane) => pane.pane_id === child.pane_id,
+							),
+							"failed delivery must retain the pane for inspection",
+						);
+						return;
+					}
+					while (
+						panes(env.workspaceId).some(
+							(pane) => pane.pane_id === child.pane_id,
+						) &&
+						Date.now() < deadline
+					)
+						await sleep(50);
+					assert.deepEqual(
+						new Set(panes(env.workspaceId).map((pane) => pane.pane_id)),
+						baseline,
+					);
+					if (scenario.name === "ordinary") {
+						deliveries.length = 0;
+						await tools.get("subagent_resume").execute(
+							"resume",
+							{
+								sessionPath: started.details.sessionFile,
+								name: "resume-order",
+								message: "Return exactly RESUMED",
+							},
+							undefined,
+							undefined,
+							ctx,
+						);
+						const resumed = panes(env.workspaceId).find(
+							(pane) => !baseline.has(pane.pane_id),
+						)!;
+						while (
+							!deliveries.some((entry) => entry.type === "subagent_result") &&
+							Date.now() < deadline
+						)
+							await sleep(50);
+						assert.ok(
+							deliveries
+								.find((entry) => entry.type === "subagent_result")
+								?.panes.includes(resumed.pane_id),
+						);
+						while (
+							panes(env.workspaceId).some(
+								(pane) => pane.pane_id === resumed.pane_id,
+							) &&
+							Date.now() < deadline
+						)
+							await sleep(50);
+						assert.deepEqual(
+							new Set(panes(env.workspaceId).map((pane) => pane.pane_id)),
+							baseline,
+						);
+					}
+				} finally {
+					await handlers.get("session_shutdown")?.({ reason: "quit" }, ctx);
+					if (previousId === undefined) delete process.env.PI_SUBAGENT_ID;
+					else process.env.PI_SUBAGENT_ID = previousId;
+				}
+			});
+
+		it("keeps the writer root shell and places a reviewer in the retained worktree tab", async () => {
+			execFileSync("git", ["init", "-q", "-b", "main"], { cwd: env.dir });
+			writeFileSync(join(env.dir, "README.md"), "fixture\n");
+			execFileSync("git", ["add", "README.md"], { cwd: env.dir });
+			execFileSync(
+				"git",
+				[
+					"-c",
+					"user.name=Test",
+					"-c",
+					"user.email=test@example.com",
+					"-c",
+					"commit.gpgsign=false",
+					"commit",
+					"-qm",
+					"fixture",
+				],
+				{ cwd: env.dir },
+			);
+			const writer = await launchPiSubagent({
+				...request(1),
+				worktree: { branch: "placement-writer" },
+			});
+			assert.ok(writer.worktree);
+			try {
+				await waitForFile(`${writer.sessionFile}.exit`, 60_000);
+				await waitForShellReady(writer.surface);
+				const root = panes(writer.worktree.workspaceId).find(
+					(pane) => pane.pane_id === writer.surface,
+				)!;
+				const reviewer = await launchPiSubagent({
+					...request(2),
+					cwd: writer.worktree.path,
+				});
+				assert.equal(
+					panes(writer.worktree.workspaceId).find(
+						(pane) => pane.pane_id === reviewer.surface,
+					)?.tab_id,
+					root.tab_id,
+				);
+				closePane(reviewer.surface);
+				assert.deepEqual(
+					panes(writer.worktree.workspaceId).map((pane) => pane.pane_id),
+					[writer.surface],
+				);
+			} finally {
+				execFileSync("herdr", [
+					"worktree",
+					"remove",
+					"--workspace",
+					writer.worktree.workspaceId,
+					"--force",
+				]);
+				// Herdr leaves the empty directory for this unique test repository.
+				rmdirSync(dirname(writer.worktree.path));
+			}
+		});
+
+		it("resolves a descendant checkout to its owning workspace despite a misleading shell cwd", async () => {
+			const other = createTestEnv(backend);
+			let checkoutWorkspace: string | undefined;
+			try {
+				process.env.HERDR_WORKSPACE_ID = env.workspaceId;
+				const checkout = join(other.dir, "repo");
+				const cwd = join(checkout, "src");
+				mkdirSync(cwd, { recursive: true });
+				execFileSync("git", ["init", "-q", "-b", "main"], { cwd: checkout });
+				execFileSync(
+					"git",
+					[
+						"-c",
+						"user.name=Test",
+						"-c",
+						"user.email=test@example.com",
+						"-c",
+						"commit.gpgsign=false",
+						"commit",
+						"--allow-empty",
+						"-qm",
+						"fixture",
+					],
+					{ cwd: checkout },
+				);
+				const created = JSON.parse(
+					execFileSync(
+						"herdr",
+						[
+							"worktree",
+							"open",
+							"--cwd",
+							checkout,
+							"--path",
+							checkout,
+							"--label",
+							"pi-integ-checkout",
+							"--no-focus",
+						],
+						{ encoding: "utf8" },
+					),
+				).result;
+				checkoutWorkspace = created.workspace.workspace_id;
+				assert.equal(created.workspace.worktree.checkout_path, checkout);
+				const misleading = JSON.parse(
+					execFileSync(
+						"herdr",
+						[
+							"tab",
+							"create",
+							"--workspace",
+							other.workspaceId,
+							"--cwd",
+							cwd,
+							"--no-focus",
+						],
+						{ encoding: "utf8" },
+					),
+				).result.root_pane.pane_id;
+				assert.equal(
+					panes(other.workspaceId).find((pane) => pane.pane_id === misleading)
+						?.cwd,
+					cwd,
+				);
+				const child = await launchPiSubagent({ ...request(1), cwd });
+				assert.ok(
+					panes(checkoutWorkspace!).some(
+						(pane) => pane.pane_id === child.surface && pane.cwd === cwd,
+					),
+					"checkout ownership must outrank another workspace's shell cwd",
+				);
+				closePane(child.surface);
+			} finally {
+				if (checkoutWorkspace)
+					execFileSync("herdr", ["workspace", "close", checkoutWorkspace]);
+				cleanupTestEnv(other);
+			}
+		});
+	});
+}

--- a/test/launch.test.ts
+++ b/test/launch.test.ts
@@ -99,8 +99,9 @@ describe("Pi launch", () => {
 			let command = "";
 			let scriptPath = "";
 			const operations: PiLaunchOperations = {
-				createPane(name) {
+				createPane(name, cwd) {
 					assert.equal(name, "Worker");
+					assert.equal(cwd, project, "placement must use the child's checkout");
 					events.push("create");
 					return "pane-1";
 				},
@@ -171,7 +172,11 @@ describe("Pi launch", () => {
 					const pane = `pane-${kind}`;
 					const closed: string[] = [];
 					const sessionFile = join(root, "resumed.jsonl");
-					writeFileSync(sessionFile, "existing session\n");
+					writeFileSync(
+						sessionFile,
+						JSON.stringify({ type: "session", id: "resumed", cwd: root }) +
+							"\n",
+					);
 					if (kind === "resume") writePublicResumePolicy(sessionFile);
 					const launchRequest: FreshPiLaunchRequest | ResumePiLaunchRequest =
 						kind === "fresh"
@@ -219,7 +224,7 @@ describe("Pi launch", () => {
 			const closed: string[] = [];
 			const operations: PiLaunchOperations = {
 				createPane: createSubagentPaneFactory(
-					{ mode: "split", direction: "down" },
+					{ mode: "split", direction: "down", maxPerTab: 4 },
 					() => {
 						throw new Error("must not create a tab");
 					},
@@ -392,7 +397,10 @@ describe("Pi launch", () => {
 			await launchPiSubagent({ ...request, name: injectedName }, operations);
 
 			const resumedSession = join(root, "resumed.jsonl");
-			writeFileSync(resumedSession, "existing session\n");
+			writeFileSync(
+				resumedSession,
+				JSON.stringify({ type: "session", id: "resumed", cwd: root }) + "\n",
+			);
 			writePublicResumePolicy(resumedSession);
 			await launchPiSubagent(
 				{
@@ -491,9 +499,12 @@ describe("Pi launch", () => {
 	});
 
 	it("resumes a session through the launch transaction", async () => {
-		await withFixture(async ({ root, sessionDir }) => {
+		await withFixture(async ({ root, project, sessionDir }) => {
 			const sessionFile = join(root, "child.jsonl");
-			writeFileSync(sessionFile, "existing session\n");
+			writeFileSync(
+				sessionFile,
+				JSON.stringify({ type: "session", id: "child", cwd: project }) + "\n",
+			);
 			writePublicResumePolicy(sessionFile);
 			const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
 			process.env.PI_CODING_AGENT_DIR = join(root, "isolated-agent");
@@ -512,8 +523,9 @@ describe("Pi launch", () => {
 					parent: { sessionId: "parent", sessionDir },
 				};
 				const operations: PiLaunchOperations = {
-					createPane(name) {
+					createPane(name, cwd) {
 						assert.equal(name, "Resume worker");
+						assert.equal(cwd, project);
 						events.push("create");
 						return "pane-resume";
 					},
@@ -597,7 +609,10 @@ describe("Pi launch", () => {
 	it("clears inherited auto-exit state when a resumed session is interactive", async () => {
 		await withFixture(async ({ root, sessionDir }) => {
 			const sessionFile = join(root, "interactive.jsonl");
-			writeFileSync(sessionFile, "existing session\n");
+			writeFileSync(
+				sessionFile,
+				JSON.stringify({ type: "session", id: "resumed", cwd: root }) + "\n",
+			);
 			writePublicResumePolicy(sessionFile);
 			const previousAutoExit = process.env.PI_SUBAGENT_AUTO_EXIT;
 			process.env.PI_SUBAGENT_AUTO_EXIT = "1";

--- a/test/test.ts
+++ b/test/test.ts
@@ -1320,6 +1320,12 @@ describe("subagent resume launch policy", () => {
 				},
 				launchOperations(commands),
 			);
+			// The mocked launch does not start Pi, which normally writes this header.
+			writeFileSync(
+				fresh.sessionFile,
+				`${JSON.stringify({ ...SESSION_HEADER, cwd: dir })}\n`,
+				"utf8",
+			);
 			const policy = readSubagentSessionPolicy(fresh.sessionFile);
 			assert.equal(policy.version, 2);
 			assert.equal(policy.owner, "public");
@@ -1905,9 +1911,10 @@ describe("status.ts", () => {
 });
 
 describe("pane configuration", () => {
-	it("defaults to tabs and rightward splits when panes are absent", () => {
+	it("defaults to four grouped panes when panes are absent", () => {
 		assert.deepEqual(parsePaneConfig({}), {
-			mode: "tab",
+			mode: "grouped",
+			maxPerTab: 4,
 			direction: "right",
 		});
 	});
@@ -1915,8 +1922,41 @@ describe("pane configuration", () => {
 	it("parses split mode and direction", () => {
 		assert.deepEqual(
 			parsePaneConfig({ panes: { mode: "split", direction: "down" } }),
-			{ mode: "split", direction: "down" },
+			{ mode: "split", direction: "down", maxPerTab: 4 },
 		);
+	});
+
+	it("loads a strict grouped capacity independently of persistent capacity", () => {
+		withTempDir((dir) => {
+			const config = join(dir, "config.json");
+			writeFileSync(
+				config,
+				JSON.stringify({
+					panes: { maxPerTab: 2 },
+					persistent: { maxAgents: 9 },
+				}),
+			);
+			assert.deepEqual(loadPaneConfig(config), {
+				mode: "grouped",
+				direction: "right",
+				maxPerTab: 2,
+			});
+			for (const maxPerTab of [
+				0,
+				-1,
+				1.5,
+				"4",
+				null,
+				true,
+				Number.MAX_SAFE_INTEGER + 1,
+			]) {
+				writeFileSync(config, JSON.stringify({ panes: { maxPerTab } }));
+				assert.throws(
+					() => loadPaneConfig(config),
+					/panes.maxPerTab must be a positive safe integer/,
+				);
+			}
+		});
 	});
 
 	it("rejects invalid pane settings", () => {
@@ -1928,7 +1968,7 @@ describe("pane configuration", () => {
 		}
 		assert.throws(
 			() => parsePaneConfig({ panes: { mode: "window" } }),
-			/panes\.mode must be "tab" or "split"/,
+			/panes\.mode must be "grouped", "tab", or "split"/,
 		);
 		assert.throws(
 			() => parsePaneConfig({ panes: { direction: "left" } }),
@@ -1950,6 +1990,7 @@ describe("pane configuration", () => {
 
 			assert.deepEqual(loadPaneConfig(join(dir, "config.json"), examplePath), {
 				mode: "split",
+				maxPerTab: 4,
 				direction: "down",
 			});
 		});
@@ -1968,7 +2009,7 @@ describe("pane configuration", () => {
 
 		assert.equal(
 			createSubagentPaneFactory(
-				{ mode: "tab", direction: "down" },
+				{ mode: "tab", direction: "down", maxPerTab: 4 },
 				createTab,
 				createSplit,
 			)("Scout"),
@@ -1976,7 +2017,7 @@ describe("pane configuration", () => {
 		);
 		assert.equal(
 			createSubagentPaneFactory(
-				{ mode: "split", direction: "right" },
+				{ mode: "split", direction: "right", maxPerTab: 4 },
 				createTab,
 				createSplit,
 			)("Reviewer"),


### PR DESCRIPTION
## Summary

Closes #33.

- Default ordinary child placement to extension-owned `Agents` tabs in the appropriate checkout workspace, with a configurable four-pane cap and tab overflow—not workspace overflow.
- Preserve explicit legacy `tab`/`split` modes, user-owned surfaces, focus, and managed worktree root shells.
- Close disposable panes only after accepted parent delivery or explicit shutdown; retain failed-delivery inspection surfaces.
- Reuse owned tabs even when only user-added panes remain, and resolve moved callers through native Herdr identity.
- Keep worktree management native. No receipts, database, restart-recovery subsystem, or version bump.

## Verification

Final corrective snapshot:

- `npm test`: **327 passed**, no failures/skips.
- `npm run test:integration`: **47 passed**, no failures/skips, real Herdr with deterministic Pi provider.
- Changed TypeScript files: confirmed-clean LSP diagnostics.
- Format, lint, package-preview contents, and Git diff checks passed.
- Native red/green regressions cover overflow, user-pane preservation/reuse, misleading checkout cwd, moved parent identity, fallback plus rejected delivery, persistent quit despite delivery errors, and retained worktree roots.
- Test-owned resources were cleaned up. Both commits have verified SSH signatures.

## Review history

- Independent Grok Standards and Spec reviews; their findings were fixed and re-reviewed.
- Fresh adversarial discovery used three Grok reviewers with separate correctness, failure-safety, and concurrency lenses. Claude Opus independently verified the candidate findings.
- Confirmed and fixed: rejected fallback-delivery cleanup (P2), persistent shutdown cleanup after event-delivery failure (P2), and stale caller-workspace fallback after a manual pane move (P3). Native red/green regressions and corrective review verified these fixes.
- Rejected: foreign-tab recovery under a response the native protocol does not emit; a pre-existing malformed-response leak whose proposed snapshot-based rollback could instead close a user pane; and a residual crash-notification claim where retention correctly follows failed delivery and the error mechanism predates this change.
- Reporting limitation: several original adversarial reports declared completion while listing coverage gaps, so their raw reports were retained as incomplete rather than presented as an unconditional all-clear. Subsequent native regressions, corrective reviews, and the full final suites resolved the actionable findings and material test gaps. No claim is made about a production provider reproducing the intentionally injected delivery failures.

## Coordination

PR #42 adds a separate side-column mode and overlaps configuration and terminal files. This PR does not incorporate or modify that work; coordinate integration before merging either.

Greptile review will be requested on the published head. No merge or release is requested by this PR.
