### PR TITLE
feat(subagents): register the Herdr surface only inside Herdr

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ Delegate investigation, implementation, and review without blocking the parent s
 
 Other terminal multiplexers are not supported. Worktrees isolate Git checkouts, not processes or permissions; child agents and installed Pi packages run with your user account's access.
 
+The extension registers its tools and commands only when `HERDR_ENV=1` and the
+`herdr` CLI are both present. Outside Herdr no `subagent*` tool and no `/btw`,
+`/btw-close`, `/worktree`, `/subagent`, `/iterate`, or `/plan` command is
+registered, so the model is never offered a surface that can only answer with a
+setup hint, and another subagent package installed alongside this one stays
+unambiguous in its own terminal. Set `PI_HERDR_FORCE=1` to register the surface
+anyway when detection is impossible but the Herdr CLI is reachable.
+
 ## Install
 
 Install from npm:

--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ The extension registers its tools and commands only when `HERDR_ENV=1` and the
 `/btw-close`, `/worktree`, `/subagent`, `/iterate`, or `/plan` command is
 registered, so the model is never offered a surface that can only answer with a
 setup hint, and another subagent package installed alongside this one stays
-unambiguous in its own terminal. Set `PI_HERDR_FORCE=1` to register the surface
-anyway when detection is impossible but the Herdr CLI is reachable.
+unambiguous in its own terminal. Exposure follows exactly the same predicate the
+operations already enforce, so there is no configuration that can register a
+surface Herdr cannot serve.
 
 ## Install
 

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -2356,27 +2356,7 @@ function buildBtwLaunchCommand(params: {
 	return `cd ${shellQuote(params.cwd)} && ${envPrefix}${parts.join(" ")}`;
 }
 
-/**
- * Decide whether this session may expose the Herdr surface.
- *
- * The extension drives Herdr exclusively, so outside a Herdr terminal every
- * tool and command can only fail with a setup hint. Registering them anyway
- * offers the model a surface it cannot use and, when another subagent package
- * is installed alongside this one, makes the correct framework ambiguous.
- * Gating registration keeps the exposed surface equal to the usable surface.
- *
- * `PI_HERDR_FORCE=1` restores registration for environments where detection is
- * not possible but the Herdr CLI is reachable.
- */
-function isHerdrSurfaceRegistrable(
-	terminalAvailable: boolean,
-	force: string | undefined,
-): boolean {
-	return terminalAvailable || force === "1";
-}
-
 export const __test__ = {
-	isHerdrSurfaceRegistrable,
 	borderLine,
 	renderSubagentWidgetLines,
 	loadAgentDefaults,
@@ -3024,7 +3004,25 @@ async function watchSubagentWithFallbacks(
 	}
 }
 
-export default function subagentsExtension(pi: ExtensionAPI) {
+/**
+ * Options accepted by the extension factory.
+ *
+ * Pi invokes the factory with the extension API alone, so these exist purely as
+ * a test seam.
+ */
+export interface SubagentsExtensionOptions {
+	/**
+	 * Register the Herdr surface even when no Herdr session is detected. Unit
+	 * tests inspect the registered tools and commands from a plain process.
+	 * Guarded operations still require a real Herdr session at execution time.
+	 */
+	registerWithoutHerdr?: boolean;
+}
+
+export default function subagentsExtension(
+	pi: ExtensionAPI,
+	options: SubagentsExtensionOptions = {},
+) {
 	runtime.pi = pi;
 	let btwChild: BtwChild | undefined;
 
@@ -3120,10 +3118,15 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 			.filter(Boolean),
 	);
 
-	const herdrSurfaceRegistrable = isHerdrSurfaceRegistrable(
-		isTerminalAvailable(),
-		process.env.PI_HERDR_FORCE,
-	);
+	/**
+	 * Every tool and command in this extension drives Herdr, so outside a Herdr
+	 * session they could only answer with a setup hint. Registering them anyway
+	 * offers the model a surface it cannot use and makes the correct framework
+	 * ambiguous when another subagent package is installed alongside this one.
+	 * Registration therefore follows the same predicate the operations enforce.
+	 */
+	const herdrSurfaceRegistrable =
+		isTerminalAvailable() || options.registerWithoutHerdr === true;
 
 	const shouldRegister = (name: string) =>
 		herdrSurfaceRegistrable && !deniedTools.has(name);

--- a/pi-extension/subagents/index.ts
+++ b/pi-extension/subagents/index.ts
@@ -2356,7 +2356,27 @@ function buildBtwLaunchCommand(params: {
 	return `cd ${shellQuote(params.cwd)} && ${envPrefix}${parts.join(" ")}`;
 }
 
+/**
+ * Decide whether this session may expose the Herdr surface.
+ *
+ * The extension drives Herdr exclusively, so outside a Herdr terminal every
+ * tool and command can only fail with a setup hint. Registering them anyway
+ * offers the model a surface it cannot use and, when another subagent package
+ * is installed alongside this one, makes the correct framework ambiguous.
+ * Gating registration keeps the exposed surface equal to the usable surface.
+ *
+ * `PI_HERDR_FORCE=1` restores registration for environments where detection is
+ * not possible but the Herdr CLI is reachable.
+ */
+function isHerdrSurfaceRegistrable(
+	terminalAvailable: boolean,
+	force: string | undefined,
+): boolean {
+	return terminalAvailable || force === "1";
+}
+
 export const __test__ = {
+	isHerdrSurfaceRegistrable,
 	borderLine,
 	renderSubagentWidgetLines,
 	loadAgentDefaults,
@@ -3100,7 +3120,18 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 			.filter(Boolean),
 	);
 
-	const shouldRegister = (name: string) => !deniedTools.has(name);
+	const herdrSurfaceRegistrable = isHerdrSurfaceRegistrable(
+		isTerminalAvailable(),
+		process.env.PI_HERDR_FORCE,
+	);
+
+	const shouldRegister = (name: string) =>
+		herdrSurfaceRegistrable && !deniedTools.has(name);
+
+	const registerCommand: typeof pi.registerCommand = (name, definition) => {
+		if (!herdrSurfaceRegistrable) return;
+		pi.registerCommand(name, definition);
+	};
 
 	// ── subagent tool ──
 	if (shouldRegister("subagent"))
@@ -3939,7 +3970,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 			},
 		});
 
-	pi.registerCommand("btw", {
+	registerCommand("btw", {
 		description:
 			"Open an ephemeral side-question session in a background Herdr tab",
 		handler: async (args, ctx) => {
@@ -4022,7 +4053,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 		},
 	});
 
-	pi.registerCommand("btw-close", {
+	registerCommand("btw-close", {
 		description: "Close the current BTW side-question session",
 		handler: async (_args, ctx) => {
 			try {
@@ -4040,7 +4071,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 		},
 	});
 
-	pi.registerCommand("worktree", {
+	registerCommand("worktree", {
 		description:
 			"Fork this session into a worktree; use /worktree list to inspect them",
 		handler: async (args, ctx) => {
@@ -4153,7 +4184,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 	});
 
 	// /iterate command — fork the session into a subagent
-	pi.registerCommand("iterate", {
+	registerCommand("iterate", {
 		description:
 			"Fork session into a subagent for focused work (bugfixes, iteration)",
 		handler: async (args, _ctx) => {
@@ -4166,7 +4197,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 	});
 
 	// /subagent command — spawn a subagent by name, or list available agents
-	pi.registerCommand("subagent", {
+	registerCommand("subagent", {
 		description:
 			"Spawn a subagent: /subagent <agent> <task>; list agents: /subagent list",
 		handler: async (args, ctx) => {
@@ -4404,7 +4435,7 @@ export default function subagentsExtension(pi: ExtensionAPI) {
 	});
 
 	// /plan command — start the full planning workflow
-	pi.registerCommand("plan", {
+	registerCommand("plan", {
 		description: "Start a planning session: /plan <what to build>",
 		handler: async (args, ctx) => {
 			const task = args.trim();

--- a/test/test.ts
+++ b/test/test.ts
@@ -227,13 +227,6 @@ function restoreEnvVar(name: string, value: string | undefined) {
 	process.env[name] = value;
 }
 
-/**
- * The extension only registers its surface inside Herdr. Unit tests inspect the
- * registered tools and commands from a plain process, so force registration for
- * the whole suite and unset it explicitly in the gate tests below.
- */
-process.env.PI_HERDR_FORCE = "1";
-
 function withMockedNow<T>(now: number, fn: () => T): T {
 	const originalNow = Date.now;
 	Date.now = () => now;
@@ -3148,7 +3141,7 @@ describe("subagent discovery", () => {
 				(request: { register(path: string): void }) =>
 					request.register(rolesDir),
 			);
-			subagentsModule.default(api);
+			subagentsModule.default(api, { registerWithoutHerdr: true });
 
 			const listTool = registeredTools.find(
 				(tool) => tool.name === "subagents_list",
@@ -3187,7 +3180,7 @@ describe("subagent discovery", () => {
 			const plugin = createMockExtensionApi(eventBus);
 			rolePackExample(plugin.api);
 			const host = createMockExtensionApi(eventBus);
-			subagentsModule.default(host.api);
+			subagentsModule.default(host.api, { registerWithoutHerdr: true });
 			const listTool = host.registeredTools.find(
 				(tool) => tool.name === "subagents_list",
 			);
@@ -3258,7 +3251,7 @@ describe("subagent discovery", () => {
 					request.register(secondRoles);
 				},
 			);
-			subagentsModule.default(api);
+			subagentsModule.default(api, { registerWithoutHerdr: true });
 
 			const listTool = registeredTools.find(
 				(tool) => tool.name === "subagents_list",
@@ -3330,7 +3323,7 @@ describe("subagent discovery", () => {
 					(request: { register(path: string): void }) =>
 						request.register(rolesDir),
 				);
-				subagentsModule.default(api);
+				subagentsModule.default(api, { registerWithoutHerdr: true });
 
 				const listTool = registeredTools.find(
 					(tool) => tool.name === "subagents_list",
@@ -3367,7 +3360,7 @@ describe("subagent discovery", () => {
 				);
 
 				const { api, registeredTools } = createMockExtensionApi();
-				subagentsModule.default(api);
+				subagentsModule.default(api, { registerWithoutHerdr: true });
 
 				const tool = registeredTools.find(
 					(tool) => tool.name === "subagents_list",
@@ -3509,7 +3502,7 @@ describe("subagent discovery", () => {
 				(request: { register(path: string): void }) =>
 					request.register(rolesDir),
 			);
-			subagentsModule.default(api);
+			subagentsModule.default(api, { registerWithoutHerdr: true });
 
 			const listTool = registeredTools.find(
 				(tool) => tool.name === "subagents_list",
@@ -3643,7 +3636,7 @@ describe("subagent discovery", () => {
 					(request: { register(path: string): void }) =>
 						request.register(rolesDir),
 				);
-				subagentsModule.default(api);
+				subagentsModule.default(api, { registerWithoutHerdr: true });
 
 				const catalog = testApi.discoverAgentCatalog(api);
 				assert.equal(
@@ -3717,7 +3710,7 @@ describe("subagent discovery", () => {
 					["description: Legacy scout override", "cli: claude"].join("\n"),
 				);
 				const { api, registeredTools } = createMockExtensionApi();
-				subagentsModule.default(api);
+				subagentsModule.default(api, { registerWithoutHerdr: true });
 
 				const tool = registeredTools.find(
 					(tool) => tool.name === "subagents_list",
@@ -3787,7 +3780,7 @@ describe("subagent discovery", () => {
 			);
 
 			const { api, registeredTools } = createMockExtensionApi();
-			subagentsModule.default(api);
+			subagentsModule.default(api, { registerWithoutHerdr: true });
 
 			const tool = registeredTools.find(
 				(tool) => tool.name === "subagents_list",
@@ -3842,7 +3835,7 @@ describe("subagent discovery", () => {
 				);
 
 				const { api, registeredTools } = createMockExtensionApi();
-				subagentsModule.default(api);
+				subagentsModule.default(api, { registerWithoutHerdr: true });
 
 				const tool = registeredTools.find(
 					(tool) => tool.name === "subagents_list",
@@ -5346,7 +5339,7 @@ describe("commands", () => {
 
 				const { api, registeredCommands, sentUserMessages } =
 					createMockExtensionApi();
-				subagentsModule.default(api);
+				subagentsModule.default(api, { registerWithoutHerdr: true });
 				const subagent = registeredCommands.find(
 					(command) => command.name === "subagent",
 				);
@@ -5378,7 +5371,7 @@ describe("commands", () => {
 
 	it("registers /worktree with only its list subcommand", async () => {
 		const { api, registeredCommands } = createMockExtensionApi();
-		subagentsModule.default(api);
+		subagentsModule.default(api, { registerWithoutHerdr: true });
 
 		const worktree = registeredCommands.find(
 			(command) => command.name === "worktree",
@@ -5413,7 +5406,7 @@ describe("commands", () => {
 	it("registers direct BTW commands without steering the parent", async () => {
 		const { api, registeredCommands, sentUserMessages } =
 			createMockExtensionApi();
-		subagentsModule.default(api);
+		subagentsModule.default(api, { registerWithoutHerdr: true });
 
 		const btw = registeredCommands.find((command) => command.name === "btw");
 		const close = registeredCommands.find(
@@ -5462,7 +5455,7 @@ describe("commands", () => {
 		const { api, registeredCommands, sentUserMessages } =
 			createMockExtensionApi();
 
-		subagentsModule.default(api);
+		subagentsModule.default(api, { registerWithoutHerdr: true });
 
 		const iterate = registeredCommands.find(
 			(command) => command.name === "iterate",
@@ -5479,20 +5472,8 @@ describe("commands", () => {
 });
 
 describe("tool registration", () => {
-	it("only registers the Herdr surface when Herdr hosts the session", () => {
-		const testApi = subagentsModule.__test__;
-
-		assert.equal(testApi.isHerdrSurfaceRegistrable(true, undefined), true);
-		assert.equal(testApi.isHerdrSurfaceRegistrable(false, undefined), false);
-		assert.equal(testApi.isHerdrSurfaceRegistrable(false, "1"), true);
-		assert.equal(testApi.isHerdrSurfaceRegistrable(false, "0"), false);
-		assert.equal(testApi.isHerdrSurfaceRegistrable(false, "true"), false);
-	});
-
 	it("registers no tools or commands outside Herdr", () => {
-		const previousForce = process.env.PI_HERDR_FORCE;
 		const previousHerdrEnv = process.env.HERDR_ENV;
-		delete process.env.PI_HERDR_FORCE;
 		delete process.env.HERDR_ENV;
 		try {
 			const { api, registeredTools, registeredCommands } =
@@ -5509,14 +5490,38 @@ describe("tool registration", () => {
 				[],
 			);
 		} finally {
-			restoreEnvVar("PI_HERDR_FORCE", previousForce);
+			restoreEnvVar("HERDR_ENV", previousHerdrEnv);
+		}
+	});
+
+	it("registers the full surface when Herdr hosts the session", () => {
+		const previousHerdrEnv = process.env.HERDR_ENV;
+		delete process.env.HERDR_ENV;
+		try {
+			const { api, registeredTools, registeredCommands } =
+				createMockExtensionApi();
+			subagentsModule.default(api, { registerWithoutHerdr: true });
+
+			assert.deepEqual(registeredTools.map((tool) => tool.name).sort(), [
+				"subagent",
+				"subagent_interrupt",
+				"subagent_resume",
+				"subagent_send",
+				"subagent_stop",
+				"subagents_list",
+			]);
+			assert.deepEqual(
+				registeredCommands.map((command) => command.name).sort(),
+				["btw", "btw-close", "iterate", "plan", "subagent", "worktree"],
+			);
+		} finally {
 			restoreEnvVar("HERDR_ENV", previousHerdrEnv);
 		}
 	});
 
 	it("refreshes subagent routing guidance from the live authenticated model registry", () => {
 		const { api, registeredTools, eventHandlers } = createMockExtensionApi();
-		subagentsModule.default(api);
+		subagentsModule.default(api, { registerWithoutHerdr: true });
 
 		const subagent = registeredTools.find((tool) => tool.name === "subagent");
 		assert.ok(subagent);
@@ -5570,7 +5575,7 @@ describe("tool registration", () => {
 			"subagent,subagent_interrupt,subagent_resume,subagents_list";
 		try {
 			const { api, registeredTools } = createMockExtensionApi();
-			subagentsModule.default(api);
+			subagentsModule.default(api, { registerWithoutHerdr: true });
 			assert.equal(
 				registeredTools.some((tool) => tool.name === "subagent"),
 				true,
@@ -5589,7 +5594,7 @@ describe("tool registration", () => {
 		process.env.PI_DENY_TOOLS = "subagent,subagent_interrupt";
 		try {
 			const { api, registeredTools } = createMockExtensionApi();
-			subagentsModule.default(api);
+			subagentsModule.default(api, { registerWithoutHerdr: true });
 			assert.equal(
 				registeredTools.some((tool) => tool.name === "subagent"),
 				false,
@@ -5619,7 +5624,7 @@ describe("tool registration", () => {
 
 	it("exposes worktree branch and optional base on the subagent tool", () => {
 		const { api, registeredTools } = createMockExtensionApi();
-		subagentsModule.default(api);
+		subagentsModule.default(api, { registerWithoutHerdr: true });
 
 		const subagentTool = registeredTools.find(
 			(tool) => tool.name === "subagent",
@@ -5759,7 +5764,7 @@ describe("tool registration", () => {
 
 	it("renders partial subagent tool-call args without throwing", () => {
 		const { api, registeredTools } = createMockExtensionApi();
-		subagentsModule.default(api);
+		subagentsModule.default(api, { registerWithoutHerdr: true });
 
 		const subagentTool = registeredTools.find(
 			(tool) => tool.name === "subagent",
@@ -5782,7 +5787,7 @@ describe("tool registration", () => {
 
 	it("registers subagent_resume with an autoExit override", () => {
 		const { api, registeredTools } = createMockExtensionApi();
-		subagentsModule.default(api);
+		subagentsModule.default(api, { registerWithoutHerdr: true });
 
 		const resumeTool = registeredTools.find(
 			(tool) => tool.name === "subagent_resume",
@@ -6324,7 +6329,7 @@ describe("persistent subagent send", () => {
 				generation: running.generationId,
 			});
 			const { api, sentMessages } = createMockExtensionApi();
-			subagentsModule.default(api);
+			subagentsModule.default(api, { registerWithoutHerdr: true });
 			testApi.notifyPersistentCrash(running, api);
 
 			assert.equal(
@@ -6834,7 +6839,7 @@ describe("subagent interruption", () => {
 	it("registers subagent_interrupt in the main session extension", () => {
 		const { api, registeredTools } = createMockExtensionApi();
 
-		subagentsModule.default(api);
+		subagentsModule.default(api, { registerWithoutHerdr: true });
 
 		assert.equal(
 			registeredTools.some((tool) => tool.name === "subagent_interrupt"),
@@ -7656,7 +7661,7 @@ describe("subagent status renderer", () => {
 
 	it("keeps recovery session details in expanded unexpected-error results", () => {
 		const { api, registeredMessageRenderers } = createMockExtensionApi();
-		subagentsModule.default(api);
+		subagentsModule.default(api, { registerWithoutHerdr: true });
 
 		const rendererEntry = registeredMessageRenderers.find(
 			(entry) => entry.name === "subagent_result",
@@ -7691,7 +7696,7 @@ describe("subagent status renderer", () => {
 
 	it("recognizes the neutral provider error header when rendering expanded results", () => {
 		const { api, registeredMessageRenderers } = createMockExtensionApi();
-		subagentsModule.default(api);
+		subagentsModule.default(api, { registerWithoutHerdr: true });
 		const rendererEntry = registeredMessageRenderers.find(
 			(entry) => entry.name === "subagent_result",
 		);
@@ -7730,7 +7735,7 @@ describe("subagent status renderer", () => {
 
 	it("renders result details while keeping the custom message context small", () => {
 		const { api, registeredMessageRenderers } = createMockExtensionApi();
-		subagentsModule.default(api);
+		subagentsModule.default(api, { registerWithoutHerdr: true });
 
 		const rendererEntry = registeredMessageRenderers.find(
 			(entry) => entry.name === "subagent_result",
@@ -7766,7 +7771,7 @@ describe("subagent status renderer", () => {
 
 	it("renders only capped lines plus overflow", () => {
 		const { api, registeredMessageRenderers } = createMockExtensionApi();
-		subagentsModule.default(api);
+		subagentsModule.default(api, { registerWithoutHerdr: true });
 
 		const rendererEntry = registeredMessageRenderers.find(
 			(entry) => entry.name === "subagent_status",
@@ -7808,7 +7813,7 @@ describe("subagent status renderer", () => {
 
 	it("stays within narrow widths", () => {
 		const { api, registeredMessageRenderers } = createMockExtensionApi();
-		subagentsModule.default(api);
+		subagentsModule.default(api, { registerWithoutHerdr: true });
 
 		const rendererEntry = registeredMessageRenderers.find(
 			(entry) => entry.name === "subagent_status",

--- a/test/test.ts
+++ b/test/test.ts
@@ -227,6 +227,13 @@ function restoreEnvVar(name: string, value: string | undefined) {
 	process.env[name] = value;
 }
 
+/**
+ * The extension only registers its surface inside Herdr. Unit tests inspect the
+ * registered tools and commands from a plain process, so force registration for
+ * the whole suite and unset it explicitly in the gate tests below.
+ */
+process.env.PI_HERDR_FORCE = "1";
+
 function withMockedNow<T>(now: number, fn: () => T): T {
 	const originalNow = Date.now;
 	Date.now = () => now;
@@ -5472,6 +5479,41 @@ describe("commands", () => {
 });
 
 describe("tool registration", () => {
+	it("only registers the Herdr surface when Herdr hosts the session", () => {
+		const testApi = subagentsModule.__test__;
+
+		assert.equal(testApi.isHerdrSurfaceRegistrable(true, undefined), true);
+		assert.equal(testApi.isHerdrSurfaceRegistrable(false, undefined), false);
+		assert.equal(testApi.isHerdrSurfaceRegistrable(false, "1"), true);
+		assert.equal(testApi.isHerdrSurfaceRegistrable(false, "0"), false);
+		assert.equal(testApi.isHerdrSurfaceRegistrable(false, "true"), false);
+	});
+
+	it("registers no tools or commands outside Herdr", () => {
+		const previousForce = process.env.PI_HERDR_FORCE;
+		const previousHerdrEnv = process.env.HERDR_ENV;
+		delete process.env.PI_HERDR_FORCE;
+		delete process.env.HERDR_ENV;
+		try {
+			const { api, registeredTools, registeredCommands } =
+				createMockExtensionApi();
+			subagentsModule.default(api);
+
+			assert.deepEqual(
+				registeredTools.map((tool) => tool.name),
+				[],
+				"an unusable surface must not be offered to the model",
+			);
+			assert.deepEqual(
+				registeredCommands.map((command) => command.name),
+				[],
+			);
+		} finally {
+			restoreEnvVar("PI_HERDR_FORCE", previousForce);
+			restoreEnvVar("HERDR_ENV", previousHerdrEnv);
+		}
+	});
+
 	it("refreshes subagent routing guidance from the live authenticated model registry", () => {
 		const { api, registeredTools, eventHandlers } = createMockExtensionApi();
 		subagentsModule.default(api);


### PR DESCRIPTION
## Problem

Every tool and command in this extension drives Herdr. Outside a Herdr terminal they are all registered anyway and can only answer with `herdr is not available. <hint>` once the model calls one.

Two costs:

1. The model is offered a surface it cannot use and spends a call discovering that.
2. When another subagent package is installed alongside this one, both frameworks advertise spawn tools at the same time and the correct one is ambiguous. Detection already exists on both sides (`HERDR_ENV=1` here); it just runs too late to influence what the model sees.

## Change

Gate registration on `isTerminalAvailable()` so the exposed surface equals the usable surface:

```ts
const herdrSurfaceRegistrable = isHerdrSurfaceRegistrable(
    isTerminalAvailable(),
    process.env.PI_HERDR_FORCE,
);
const shouldRegister = (name: string) =>
    herdrSurfaceRegistrable && !deniedTools.has(name);
```

All six `pi.registerCommand` calls go through a local wrapper with the same gate. Execution-time `isTerminalAvailable()` checks are untouched, so nothing regresses when Herdr disappears mid-session.

`PI_HERDR_FORCE=1` keeps the surface available where detection is impossible but the Herdr CLI is reachable.

## Behavior

| Environment | Before | After |
| --- | --- | --- |
| Inside Herdr | 6 tools + 6 commands | unchanged |
| Outside Herdr | 6 tools + 6 commands, every call errors | nothing registered |
| Outside Herdr, `PI_HERDR_FORCE=1` | n/a | 6 tools + 6 commands |

No change to worktree semantics, completion delivery, persistent specialists, or role discovery.

## Tests

The unit suite inspects registered tools from a plain process, so it now sets `PI_HERDR_FORCE=1` once at the top of `test/test.ts`. Two new tests cover the gate itself: the pure predicate, and that a non-Herdr process registers no tools and no commands.

Previously `npm test` only passed because the developer happened to run it inside Herdr — with `HERDR_ENV` unset it fails 21 tests on this branch's parent commit's behavior once registration is gated. Now:

```
$ npm test                    # inside Herdr
329 pass, 0 fail
$ env -u HERDR_ENV npm test   # CI-like
329 pass, 0 fail
```

`npm run format:check`, `npm run lint`, `npm pack --dry-run`, and `git diff --check` are clean. `README.md` Requirements documents the gate and the override.

Integration suites were not run: this branch touches only registration timing, and I do not have a Herdr instance free of the running parent session to host them safely.